### PR TITLE
Overhaul Filter Param

### DIFF
--- a/components/parameters/FilterParam.yml
+++ b/components/parameters/FilterParam.yml
@@ -4,14 +4,4 @@ in: query
 required: false
 schema:
   type: object
-  additionalProperties:
-    type: string
-    oneOf:
-      - type: string
-      - type: array
-        items:
-          type: string
-      - type: object
-        additionalProperties:
-          type: string
 style: deepObject

--- a/public/paths/containers/containers.yml
+++ b/public/paths/containers/containers.yml
@@ -43,50 +43,51 @@ get:
             - environments
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Identifier
-        `filter[identifier]=value` List only those containers matching this identifier. May return multiple results.
-
-        ### Search
-        `filter[search]=value` search containers for a value associated with a field on the given container(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the container's current state.
-
-        ### Service
-        `filter[service]=value` service filtering will allow you to filter by service type: `loadbalancer`, `discovery`, `vpn`.
-
-        ### Public Network
-        `filter[public_network]=value` public network filtering will allow you to filter by the containers network settings: `enabled`, `disabled`, `egress-only`.
-
-        ### Image 
-        `filter[image]=ID` image filtering by ID.  Submit the ID of the image you wish to filter for and the return will be any containers currently using the image.
-
-        ### Environment
-        `filter[environment]=ID` environment filtering by ID.  Submit the ID of the environment you wish to filter for and the return will be any containers in that environment.
-
-        ### Tags
-        `filter[tags]=tagone,tagtwo,tagthree` container filtering using server tags. If the container has the tags you submit it will be part of the return. 
-
-        ### Stacks
-        `filter[stack]=ID` stack filtering by ID.  Submit the ID of the stack you wish to filter for and the return will be any containers deployed associated with 'containers' from the stack.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
-      style: deepObject
-
+        properties:
+          identifier:
+            type: string
+            description: | 
+              `filter[identifier]=value` List only those containers matching this identifier. May return multiple results.
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search containers for a value associated with a field on the given container(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the container's current state.
+          service: 
+            type: string
+            description: |
+              `filter[service]=value` service filtering will allow you to filter by service type: `loadbalancer`, `discovery`, `vpn`.
+          public_network:
+            type: string
+            description: |
+              `filter[public_network]=value` public network filtering will allow you to filter by the containers network settings: `enabled`, `disabled`, `egress-only`.
+          image:
+            type: string
+            description: |
+              `filter[image]=ID` image filtering by ID.  Submit the ID of the image you wish to filter for and the return will be any containers currently using the image.
+          environment:
+            type: string
+            description: |
+              `filter[environment]=ID` environment filtering by ID.  Submit the ID of the environment you wish to filter for and the return will be any containers in that environment.
+          tags:
+            type: string
+            description: |
+              `filter[tags]=tagone,tagtwo,tagthree` container filtering using server tags. If the container has the tags you submit it will be part of the return. 
+          stack:
+            type: string
+            description: |
+              `filter[stack]=ID` stack filtering by ID.  Submit the ID of the stack you wish to filter for and the return will be any containers deployed associated with 'containers' from the stack.
     - $ref: ../../../components/parameters/SortParam.yml
     - $ref: ../../../components/parameters/PageParam.yml
   responses:

--- a/public/paths/containers/instances/instances.yml
+++ b/public/paths/containers/instances/instances.yml
@@ -31,32 +31,27 @@ get:
     - name: filter
       in: query
       required: false
+       # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the instance's current state.
-
-        ### Search 
-        `filter[search]=value` search instances for a value associated with a field on the given instance(s).
-
-        ### Server
-        `filter[server]=ID` server filtering by ID.  Submit the ID of the server you wish to filter for and the return will be any instances of the container currently deployed to the given server.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
-
+        properties:
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the instance's current state.
+          search: 
+            type: string
+            description: |
+              `filter[search]=value` search instances for a value associated with a field on the given instance(s).
+          server:
+            type: string
+            description: |
+              `filter[server]=ID` server filtering by ID. Submit the ID of the server you wish to filter for and the return will be any instances of the container currently deployed to the given server.
     - $ref: ../../../../components/parameters/SortParam.yml
-
     - $ref: ../../../../components/parameters/PageParam.yml
   summary: List Instances
   description: Requires the `containers-view` capability.

--- a/public/paths/containers/instances/telemetry/report.yml
+++ b/public/paths/containers/instances/telemetry/report.yml
@@ -18,22 +18,20 @@ get:
     - name: filter
       in: query
       required: false
+       # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Range 
-        `filter[range-start]=timestamp&filter[range-end]=timestamp` filter by range giving two times a `start` time and an `end` time. Date format `2023-03-07T14:55:17-08:00`
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          range-start:
+            description: The start date from when to pull instance telemetry data
+            $ref: ../../../../../components/schemas/DateTime.yml
+          range-end:
+            description: The end date from when to pull instance telemetry data
+            $ref: ../../../../../components/schemas/DateTime.yml
   summary: Fetch Instance Telemetry Report
   description: Requires the `containers-view` capability.
   responses:

--- a/public/paths/containers/telemetry.yml
+++ b/public/paths/containers/telemetry.yml
@@ -11,25 +11,21 @@ get:
         type: string
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Range 
-        `filter[range-start]=timestamp&filter[range-end]=timestamp` filter by range giving two times a `start` time and an `end` time. Date format `2023-03-07T14:55:17-08:00`.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
-      style: deepObject
+        properties:
+          range-start:
+            description: The start date from when to pull instance telemetry data
+            $ref: ../../../components/schemas/DateTime.yml
+          range-end:
+            description: The end date from when to pull instance telemetry data
+            $ref: ../../../components/schemas/DateTime.yml
   summary: List Telemetry Data
   description: Requires the `containers-view` capability.
   responses:

--- a/public/paths/dns/records/records.yml
+++ b/public/paths/dns/records/records.yml
@@ -26,25 +26,20 @@ get:
             - containers
     - name: filter
       in: query
+       # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the record's current state.
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the DNS record's current state.
     - $ref: ../../../../components/parameters/SortParam.yml
-
     - $ref: ../../../../components/parameters/PageParam.yml
   summary: List Records
   description: Requires the `dns-view` capability.

--- a/public/paths/dns/tls/attempts.yml
+++ b/public/paths/dns/tls/attempts.yml
@@ -5,26 +5,20 @@ get:
   parameters:
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Domain
-        `filter[domain]=value` filter the return for TLS attempts by domain.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          domain:
+            type: string
+            description: |
+              `filter[domain]=value` filter the return for TLS attempts by domain.
     - $ref: ../../../../components/parameters/SortParam.yml
-
     - $ref: ../../../../components/parameters/PageParam.yml
   summary: List TLS Generate Attempts
   description: Requires the `dns-view` capability.

--- a/public/paths/dns/zones.yml
+++ b/public/paths/dns/zones.yml
@@ -19,26 +19,20 @@ get:
             - creators
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the DNS zone's current state.
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
-
+        properties:
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the DNS zone's current state.
     - $ref: ../../../components/parameters/SortParam.yml
-
     - $ref: ../../../components/parameters/PageParam.yml
   summary: List DNS Zones
   description: Requires the `dns-view` capability.

--- a/public/paths/environments/environments.yml
+++ b/public/paths/environments/environments.yml
@@ -38,35 +38,32 @@ get:
             - stacks
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Identifier
-        `filter[identifier]=value` List only those environments matching this identifier. May return multiple results.
-
-        ### Search 
-        `filter[search]=value` search for a value associated with a field on the given environment(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the environment's current state.
-
-        ### Stack Build
-        `filter[stack_build]=ID` stack build filtering by ID.  Submit the ID of the stack build you wish to filter for and the return sill be any environments that have the stack build deployed to them.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          identifier:
+            type: string
+            description: |
+              `filter[identifier]=value` List only those environments matching this identifier. May return multiple results.
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search for a value associated with a field on the given environment(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the environment's current state.
+          stack_build:
+            type: string
+            description: |
+              `filter[stack_build]=ID` stack build filtering by ID.  Submit the ID of the stack build you wish to filter for and the return sill be any environments that have the stack build deployed to them.
     - $ref: ../../../components/parameters/SortParam.yml
-
     - $ref: ../../../components/parameters/PageParam.yml
   summary: List Environments
   description: Requires the `environments-view` capability.

--- a/public/paths/environments/scoped-variables.yml
+++ b/public/paths/environments/scoped-variables.yml
@@ -15,23 +15,21 @@ get:
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Search 
-        `filter[search]=value` search for a value associated with a field on the given scoped variable(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the scoped variable's current state.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          identifier:
+            type: string
+            description: |
+              `filter[identifier]=value` List only those environments matching this identifier. May return multiple results.
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search for a value associated with a field on the given scoped variable(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the scoped variable's current state.
     - $ref: ../../../components/parameters/SortParam.yml
 
     - $ref: ../../../components/parameters/PageParam.yml

--- a/public/paths/environments/telemetry.yml
+++ b/public/paths/environments/telemetry.yml
@@ -11,24 +11,21 @@ get:
         type: string
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Range 
-        `filter[range-start]=timestamp&filter[range-end]=timestamp` filter by range giving two times a `start` time and an `end` time. Date format `2023-03-07T14:55:17-08:00`.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          range-start:
+            description: The start date from when to pull instance telemetry data
+            $ref: ../../../components/schemas/DateTime.yml
+          range-end:
+            description: The end date from when to pull instance telemetry data
+            $ref: ../../../components/schemas/DateTime.yml
   summary: List Telemetry Data
   description: Requires the `environments-view` capability.
   responses:

--- a/public/paths/hubs/activity.yml
+++ b/public/paths/hubs/activity.yml
@@ -25,52 +25,54 @@ get:
             - environments
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Search
-        `filter[search]=value` search activities for a value associated with a field on the given activity(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the activity's current state.
-
-        ### User 
-        `filter[user]=ID` user filtering by ID.  Submit the ID of the user you wish to filter for and the return will be any activity from that user.
-
-        ### Environment
-        `filter[environment]=ID` environment filtering by ID.  Submit the ID of the environment you wish to filter for and the return will be any activity from that environment.
-
-        ### container
-        `filter[container]=ID` container filtering by ID.  Submit the ID of the container you wish to filter for and the return will be any activity from that container.
-
-        ### Instance
-        `filter[instance]=ID` instance filtering by ID.  Submit the ID of the instance you wish to filter for and the return will be any activity from that instance.
-
-        ### Server
-        `filter[server]=ID` server filtering by ID.  Submit the ID of the server you wish to filter for and the return will be any activity from that server.
-
-        ### Event
-        `filter[event]=value` filter by event occurrence. Example: `filter[event]=environment.services.vpn.login`
-
-        ### Verbosity
-        `filter[verbosity]=integer` filter the activity return by verbosity. The verbosity can be:
-
-          `0` - Activity that users would find useful.
-          `1` - Activity that can be useful when tracking down how something happened. 
-          `2` - Full activity, can be useful in debugging problems.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search activities for a value associated with a field on the given activity(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the activity's current state.
+          user:
+            type: string
+            description: |
+              `filter[user]=ID` user filtering by ID. Submit the ID of the user you wish to filter for and the return will be any activity from that user.
+          environment:
+            type: string
+            description: |
+              `filter[environment]=ID` environment filtering by ID. Submit the ID of the environment you wish to filter for and the return will be any activity from that environment.
+          container:
+            type: string
+            description: |
+              `filter[container]=ID` container filtering by ID. Submit the ID of the container you wish to filter for and the return will be any activity from that container.
+          instance:
+            type: string
+            description: |
+              `filter[instance]=ID` instance filtering by ID. Submit the ID of the instance you wish to filter for and the return will be any activity from that instance.
+          server:
+            type: string
+            description: |
+              `filter[server]=ID` server filtering by ID. Submit the ID of the server you wish to filter for and the return will be any activity from that server.
+          event:
+            type: string
+            description: |
+              `filter[event]=value` filter by event occurrence. Example: `filter[event]=environment.services.vpn.login`
+          verbosity:
+            type: integer
+            description: |
+              `filter[verbosity]=integer` filter the activity return by verbosity. The verbosity can be:
+                `0` - Activity that users would find useful.
+                `1` - Activity that can be useful when tracking down how something happened. 
+                `2` - Full activity, can be useful in debugging problems.
     - $ref: ../../../components/parameters/SortParam.yml
     - $ref: ../../../components/parameters/PageParam.yml
   summary: List Activity

--- a/public/paths/hubs/hubs.yml
+++ b/public/paths/hubs/hubs.yml
@@ -9,30 +9,27 @@ get:
   parameters:
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Identifier
-        `filter[identifier]=value` List only those hubs matching this identifier. May return multiple results.
-
-        ### Search
-        `filter[search]=value` search hubs for a value associated with a field on the given hub(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the hub's current state.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          identifier:
+            type: string
+            description: |
+              `filter[identifier]=value` List only those environments matching this identifier. May return multiple results.
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search hubs for a value associated with a field on the given hub(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the hub's current state.
   responses:
     200:
       description: Returns a list of hub resources.

--- a/public/paths/images/images.yml
+++ b/public/paths/images/images.yml
@@ -39,34 +39,36 @@ get:
             - sources
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       # TODO - source type isnt implemented correctly see notes
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Search 
-        `filter[search]=value` search for a value associated with a field on the given image(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the image's current state.
-
-        ### Source Type
-        `filter[source_type]=value` filter images by the image source's type.  Can be: `direct` or `stack_build`
-
-        ### Source
-        `filter[source_id]=ID` image filtering by source ID.  Submit the ID of the image source you wish to filter for and the return will be any images created from that source.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          identifier:
+            type: string
+            description: |
+              `filter[identifier]=value` List only those images matching this identifier. May return multiple results.
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search for a value associated with a field on the given image(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the image's current state.
+          source_type:
+            type: string
+            description: |
+              `filter[source_type]=value` filter images by the image source's type.  Can be: `direct` or `stack_build`
+          source_id:
+            type: string
+            description: |
+              `filter[source_id]=ID` image filtering by source ID.  Submit the ID of the image source you wish to filter for and the return will be any images created from that source.
     - $ref: ../../../components/parameters/SortParam.yml
 
     - $ref: ../../../components/parameters/PageParam.yml

--- a/public/paths/images/sources/sources.yml
+++ b/public/paths/images/sources/sources.yml
@@ -34,30 +34,27 @@ get:
             - creators
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Identifier
-        `filter[identifier]=value` List only those image sources matching this identifier. May return multiple results.
-
-        ### Search 
-        `filter[search]=value` search for a value associated with a field on the given image source(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the image source's current state.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          identifier:
+            type: string
+            description: |
+              `filter[identifier]=value` List only those image sources matching this identifier. May return multiple results.
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search for a value associated with a field on the given image source(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the image source's current state.
     - $ref: ../../../../components/parameters/SortParam.yml
 
     - $ref: ../../../../components/parameters/PageParam.yml

--- a/public/paths/infrastructure/providers/native.yml
+++ b/public/paths/infrastructure/providers/native.yml
@@ -20,24 +20,19 @@ get:
             - locations
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Search 
-        `filter[search]=value` search for a value associated with a field on the given native provider(s).
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search for a value associated with a field on the given native provider(s).
     - $ref: ../../../../components/parameters/SortParam.yml
 
     - $ref: ../../../../components/parameters/PageParam.yml

--- a/public/paths/infrastructure/providers/providers.yml
+++ b/public/paths/infrastructure/providers/providers.yml
@@ -22,30 +22,24 @@ get:
             - locations
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Search 
-        `filter[search]=value` search for a value associated with a field on the given provider(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the provider's current state.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
-
+        properties:
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search for a value associated with a field on the given provider(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the provider's current state.
     - $ref: ../../../../components/parameters/SortParam.yml
-
     - $ref: ../../../../components/parameters/PageParam.yml
   summary: List Providers
   description: Requires the `infrastructure-providers-view` capability.

--- a/public/paths/infrastructure/servers/servers.yml
+++ b/public/paths/infrastructure/servers/servers.yml
@@ -37,33 +37,31 @@ get:
             - providers
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the provider's current state.
-
-        ### Tags
-        `filter[tags]=tagone,tagtwo,tagthree` filtering by server tag.  Enter one or more tags (comma separated) and the return will include servers that match any tags in the list.
-
-        ### Clusters
-        `filter[clusters]=clusterone,clustertwo` filtering by cluster.  Enter one or more clusters (commas separated) and the return will include servers that match any clusters in the list.
-
-        ### Providers
-        `filter[providers]=providerone,providertwo` filtering by provider.  Enter one or more providers (commas separated) and the return will include servers that match any providers in the list.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the provider's current state.
+          tags:
+            type: string
+            description: |
+              `filter[tags]=tagone,tagtwo,tagthree` filtering by server tag.  Enter one or more tags (comma separated) and the return will include servers that match any tags in the list.
+          clusters:
+            type: string
+            description: |
+              `filter[clusters]=clusterone,clustertwo` filtering by cluster.  Enter one or more clusters (commas separated) and the return will include servers that match any clusters in the list.
+          providers:
+            type: string
+            description: |
+              `filter[providers]=providerone,providertwo` filtering by provider.  Enter one or more providers (commas separated) and the return will include servers that match any providers in the list.
     - $ref: "../../../../components/parameters/SortParam.yml"
     - $ref: "../../../../components/parameters/PageParam.yml"
   summary: List Servers

--- a/public/paths/infrastructure/servers/tags.yml
+++ b/public/paths/infrastructure/servers/tags.yml
@@ -5,25 +5,19 @@ get:
   parameters:
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Cluster
-        `filter[cluster]=clusterone,clustertwo` filtering by cluster.  Enter one or more clusters (commas separated) and the return will include tags from servers that match any cluster(s) in the list.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
-
+        properties:
+          cluster:
+            type: string
+            description: |
+              `filter[cluster]=clusterone,clustertwo` filtering by cluster.  Enter one or more clusters (commas separated) and the return will include tags from servers that match any cluster(s) in the list.
   summary: List Server Tags
   description: Requires the `servers-view` capability.
   responses:

--- a/public/paths/infrastructure/servers/telemetry.yml
+++ b/public/paths/infrastructure/servers/telemetry.yml
@@ -11,24 +11,21 @@ get:
         type: string
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Range 
-        `filter[range-start]=timestamp&filter[range-end]=timestamp` filter by range giving two times a `start` time and an `end` time. Date format `2023-03-07T14:55:17-08:00`.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          range-start:
+            description: The start date from when to pull server telemetry data
+            $ref: ../../../../components/schemas/DateTime.yml
+          range-end:
+            description: The end date from when to pull server telemetry data
+            $ref: ../../../../components/schemas/DateTime.yml
     - $ref: "../../../../components/parameters/SortParam.yml"
     - $ref: "../../../../components/parameters/PageParam.yml"
   summary: List Server Telemetry

--- a/public/paths/infrastructure/summary.yml
+++ b/public/paths/infrastructure/summary.yml
@@ -6,22 +6,18 @@ get:
     - name: filter
       in: query
       required: false
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Search 
-        `filter[cluster]=value` return an infrastructure summary only for the specified cluster.
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          cluster:
+            type: string
+            description: |
+              `filter[cluster]=value` return an infrastructure summary only for the specified cluster.
   summary: Fetch Infrastructure Summary
   description: Requires the `infrastructure-servers-view` capability.
   responses:

--- a/public/paths/jobs/jobs.yml
+++ b/public/paths/jobs/jobs.yml
@@ -20,32 +20,30 @@ get:
 
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Range 
-        `filter[range-start]=timestamp&filter[range-end]=timestamp` filter by range giving two times a `start` time and an `end` time. Date format `2023-03-07T14:55:17-08:00`.
-
-        ### Search
-        `filter[search]=value` search jobs for a value associated with a field on the given job(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the job's current state.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          range-start:
+            description: The start date from when to fetch jobs
+            $ref: ../../../components/schemas/DateTime.yml
+          range-end:
+            description: The end date from when to fetch jobs
+            $ref: ../../../components/schemas/DateTime.yml
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search jobs for a value associated with a field on the given job(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the job's current state.
     - $ref: ../../../components/parameters/SortParam.yml
-
     - $ref: ../../../components/parameters/PageParam.yml
   summary: List Jobs.
   description: Requires the `jobs-view` permission.

--- a/public/paths/pipelines/pipelines.yml
+++ b/public/paths/pipelines/pipelines.yml
@@ -21,30 +21,27 @@ get:
             - components
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
-        ## Filter Field
+        ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Identifier
-        `filter[identifier]=value` List only those pipelines matching this identifier. May return multiple results.
-        
-        ### Search
-        `filter[search]=value` search pipelines for a value associated with a field on the given pipeline(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the pipeline's current state.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          identifier:
+            type: string
+            description: |
+              `filter[identifier]=value` List only those pipelines matching this identifier. May return multiple results.
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search for a value associated with a field on the given pipelines(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the pipeline's current state.
     - $ref: ../../../components/parameters/SortParam.yml
 
     - $ref: ../../../components/parameters/PageParam.yml

--- a/public/paths/pipelines/trigger-keys/trigger-keys.yml
+++ b/public/paths/pipelines/trigger-keys/trigger-keys.yml
@@ -11,29 +11,24 @@ get:
         type: string
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
-        ## Filter Field
+        ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Search
-        `filter[search]=value` search trigger keys for a value associated with a field on the given trigger key(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the trigger key's current state.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search for a value associated with a field on the given trigger key(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the trigger key's current state.
     - $ref: ../../../../components/parameters/SortParam.yml
-
     - $ref: ../../../../components/parameters/PageParam.yml
   summary: List Trigger Keys
   description: Requires the `pipelines-manage` capability.

--- a/public/paths/sdn/networks.yml
+++ b/public/paths/sdn/networks.yml
@@ -21,27 +21,23 @@ get:
 
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
-        ## Filter Field
+        ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Search
-        `filter[search]=value` search networks for a value associated with a field on the given network(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the network's current state.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search for a value associated with a field on the given network(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the network's current state.
     - $ref: ../../../components/parameters/SortParam.yml
 
     - $ref: ../../../components/parameters/PageParam.yml

--- a/public/paths/security/report.yml
+++ b/public/paths/security/report.yml
@@ -7,27 +7,23 @@ get:
   parameters:
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
         ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Environment
-        `filter[environment]=<Environment ID>` fetch the security report for the specified environment
-
-        ### Event
-        `filter[event]=value` filter by event occurrence. Example: `filter[event]=environment.services.vpn.login`
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          environment:
+            type: string
+            description: |
+              `filter[environment]=<Environment ID>` fetch the security report for the specified environment
+          event:
+            type: string
+            description: |
+              `filter[event]=value` filter by event occurrence. Example: `filter[event]=environment.services.vpn.login`
   responses:
     200:
       description: Returns the security report.

--- a/public/paths/stacks/builds/builds.yml
+++ b/public/paths/stacks/builds/builds.yml
@@ -46,27 +46,23 @@ get:
 
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
-        ## Filter Field
+        ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Search
-        `filter[search]=value` search stack builds for a value associated with a field on the given stack build(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the stack build's current state.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search for a value associated with a field on the given stack build(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the stack build's current state.
     - $ref: ../../../../components/parameters/SortParam.yml
 
     - $ref: ../../../../components/parameters/PageParam.yml

--- a/public/paths/stacks/stacks.yml
+++ b/public/paths/stacks/stacks.yml
@@ -38,30 +38,27 @@ get:
 
     - name: filter
       in: query
+      # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706
+      style: deepObject
       required: false
       description: |
-        ## Filter Field
+        ## Filter Field 
         The filter field is a key-value object, where the key is what you would like to filter, and the value is the value you're filtering for.
-
-        ## Possible Values
-        ### Identifier
-        `filter[identifier]=value` List only those stacks matching this identifier. May return multiple results.
-
-        ### Search
-        `filter[search]=value` search stacks for a value associated with a field on the given stack(s).
-
-        ### State
-        `filter[state]=value1,value2` state filtering will allow you to filter by the stack's current state.
-
       schema:
         type: object
-        additionalProperties:
-          type: string
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
+        properties:
+          identifier:
+            type: string
+            description: |
+              `filter[identifier]=value` List only those stacks matching this identifier. May return multiple results.
+          search:
+            type: string
+            description: |
+              `filter[search]=value` search for a value associated with a field on the given stack(s).
+          state:
+            type: string
+            description: |
+              `filter[state]=value1,value2` state filtering will allow you to filter by the stack's current state.
     - $ref: ../../../components/parameters/SortParam.yml
     - $ref: ../../../components/parameters/PageParam.yml
   responses:


### PR DESCRIPTION
It turns out the way our filter param was implemented was not technically valid.

![image](https://github.com/cycleplatform/api-spec/assets/5110855/3a222fda-3fa3-4a13-8f5b-5be918e6a0d0)

According to this chart, `deepObject` does not currently support an array value for an object in a parameter. Therefore, in order to better conform with the spec and to make code/documentation generators more compliant, I have removed the array option.

I also took this opportunity to be more explicit about the names of the filter parameters, so they are much better documented now.

There is an open issue on the topic here: https://github.com/OAI/OpenAPI-Specification/issues/1706