### PR TITLE
Add missing activity properties

### DIFF
--- a/components/schemas/hubs/activity/Activity.yml
+++ b/components/schemas/hubs/activity/Activity.yml
@@ -7,7 +7,7 @@ required:
   - user
   - verbosity
   - context
-  # - session
+  - session
   - changes
   - annotations
   - error
@@ -40,19 +40,28 @@ properties:
           - "visitor"
       id:
         type: string
-        description: The given users ID.
+        description: The given user's ID.
   verbosity:
     type: integer
-    description: A number representing how verbose the acitivty reporting is for a given hub.
+    description: |
+      A number representing the detail level (verbosity) of this activity.
+
+      ## Levels
+      - 0: activity that other users would find useful
+      - 1: activity that can be useful in tracking down how a user did something
+      - 2: full activity, can be useful in debugging problems
   context:
-    "$ref": "./Context.yml"
+    $ref: Context.yml
   session:
-    "$ref": "./Session.yml"
+    type: object
+    nullable: true
+    anyOf:
+      - $ref: Session.yml
   changes:
     type: array
     description: An array of changes.
     items:
-      "$ref": "./Change.yml"
+      $ref: Change.yml
   annotations:
     type: object
     description: A record of additional annotations for the activity.
@@ -91,141 +100,182 @@ properties:
     description: A status for the given activity.
     enum:
       - info
-      - warning
+      - warn
       - request
       - success
       - error
       - alert
-      - recovery
+  security:
+    $ref: ActivitySecurity.yml
+  monitor:
+    $ref: ActivityMonitor.yml
   event:
     type: string
     description: The activity event.
     enum:
-      - "hub.task.delete"
-      - "hub.update"
-      - "hub.create"
-      - "hub.images.prune"
-      - "hub.task.images.prune"
-      - "environment.initialize"
-      - "environment.start"
-      - "environment.stop"
-      - "environment.task.start"
-      - "environment.task.stop"
-      - "environment.task.initialize"
-      - "environment.delete"
-      - "environment.task.delete"
-      - "environment.update"
-      - "environment.create"
-      - "environment.services.discovery.task.reconfigure"
-      - "environment.services.lb.task.reconfigure"
-      - "environment.services.vpn.task.reconfigure"
-      - "image.import"
-      - "image.task.import"
-      - "image.update"
-      - "image.create"
-      - "image.delete"
-      - "image.task.delete"
-      - "image.source.create"
-      - "image.source.update"
-      - "image.source.task.delete"
-      - "container.create"
-      - "container.update"
-      - "container.initialize"
-      - "container.start"
-      - "container.task.start"
-      - "container.stop"
-      - "container.task.stop"
-      - "container.reconfigure"
-      - "container.task.reconfigure"
-      - "container.reconfigure.volumes"
-      - "container.task.reconfigure.volumes"
-      - "container.reimage"
-      - "container.task.reimage"
-      - "container.scale"
-      - "container.task.scale"
-      - "container.delete"
-      - "container.task.delete"
-      - "container.instance.error"
-      - "container.instance.sftp.login"
-      - "container.instance.migration.start"
-      - "container.instance.migration.revert"
-      - "container.instance.delete"
-      - "container.instances.delete"
-      - "container.instances.create"
-      - "container.instance.healthcheck.restarted"
-      - "container.backup.create"
-      - "container.backup.restore"
-      - "container.backup.task.restore"
-      - "container.backup.delete"
-      - "container.backup.task.delete"
-      - "dns.zone.task.verify"
-      - "dns.zone.task.delete"
-      - "dns.zone.update"
-      - "dns.zone.create"
-      - "dns.zone.verify"
-      - "dns.zone.delete"
-      - "dns.zone.record.cert.generate.auto"
-      - "dns.zone.record.cert.generate"
-      - "dns.zone.record.delete"
-      - "dns.zone.record.update"
-      - "dns.zone.record.create"
-      - "dns.zone.record.task.delete"
-      - "dns.zone.record.task.cert.generate"
-      - "stack.task.delete"
-      - "stack.update"
-      - "stack.create"
-      - "stack.task.prune"
-      - "stack.build.create"
-      - "stack.build.generate"
-      - "stack.build.deploy"
-      - "stack.build.delete"
-      - "stack.build.task.generate"
-      - "stack.build.task.delete"
-      - "infrastructure.server.task.delete"
-      - "infrastructure.server.task.restart"
-      - "infrastructure.server.task.provision"
-      - "infrastructure.server.update"
-      - "infrastructure.server.delete"
-      - "infrastructure.server.restart"
-      - "infrastructure.server.compute.restart"
-      - "infrastructure.server.provision"
-      - "infrastructure.server.live"
-      - "infrastructure.server.services.sftp.lockdown.auto"
-      - "infrastructure.server.reconfigure.features"
-      - "infrastructure.server.task.reconfigure.features"
-      - "infrastructure.provider.create"
-      - "infrastructure.provider.update"
-      - "infrastructure.provider.delete"
-      - "sdn.network.task.delete"
-      - "sdn.network.update"
-      - "sdn.network.create"
-      - "sdn.network.task.reconfigure"
-      - "infrastructure.ips.pool.task.delete"
-      - "billing.order.task.confirm"
-      - "billing.order.confirm"
-      - "billing.invoice.task.void"
-      - "billing.invoice.task.credit"
-      - "billing.invoice.task.refund"
-      - "billing.invoice.task.pay"
-      - "billing.invoice.pay"
-      - "billing.method.update"
-      - "billing.method.create"
-      - "billing.method.delete"
-      - "billing.method.task.delete"
-      - "hub.apikey.create"
-      - "hub.apikey.update"
-      - "hub.apikey.delete"
-      - "hub.membership.create"
-      - "hub.membership.delete"
-      - "pipeline.update"
-      - "pipeline.task.delete"
-      - "pipeline.delete"
-      - "pipeline.create"
-      - "pipeline.task.trigger"
-      - "pipeline.trigger"
-      - "pipeline.key.update"
-      - "pipeline.key.delete"
-      - "pipeline.key.create"
+      - hub.images.prune
+      - hub.update
+      - hub.create
+      - hub.task.delete
+      - hub.task.images.prune
+
+      - environment.services.discovery.reconfigure
+      - environment.services.lb.reconfigure
+      - environment.services.vpn.reconfigure
+      - environment.delete
+      - environment.initialize
+      - environment.start
+      - environment.stop
+      - environment.create
+      - environment.update
+      - environment.task.delete
+      - environment.services.discovery.task.reconfigure
+      - environment.services.lb.task.reconfigure
+      - environment.services.vpn.task.reconfigure
+      - environment.vpn.user.create
+      - environment.task.initialize
+      - environment.task.start
+      - environment.task.stop
+
+      - environment.scoped-variable.delete
+      - environment.scoped-variable.update
+      - environment.scoped-variable.task.delete
+      - environment.scoped-variable.create
+
+      - image.delete
+      - image.import
+      - image.create
+      - image.update
+      - image.task.delete
+      - image.task.import
+
+      - image.source.delete
+      - image.source.create
+      - image.source.update
+      - image.source.task.delete
+
+      - billing.invoice.task.void
+      - billing.invoice.task.credit
+      - billing.invoice.task.refund
+      - billing.invoice.pay
+      - billing.invoice.task.pay
+
+      - billing.order.confirm
+      - billing.order.task.confirm
+
+      - billing.method.update
+      - billing.method.delete
+      - billing.method.task.delete
+      - billing.method.create
+
+      - infrastructure.provider.update
+      - infrastructure.provider.task.delete
+      - infrastructure.provider.create
+      - infrastructure.provider.task.verify
+
+      - hub.apikey.update
+      - hub.apikey.delete
+      - hub.apikey.create
+
+      - hub.membership.delete
+      - hub.membership.create
+      - hub.membership.update
+
+      - container.intialize
+      - container.delete
+      - container.start
+      - container.stop
+      - container.reconfigure
+      - container.reconfigure.volumes
+      - container.reimage
+      - container.scale
+      - container.instances.create
+      - container.instances.delete
+      - container.create
+      - container.restart
+      - container.reimage
+      - container.update
+      - container.task.delete
+      - container.task.scale
+
+      - container.instance.healthcheck.restarted
+      - container.instance.error
+      - container.instance.ssh.login
+      - container.instance.migration.start
+      - container.instance.migration.revert
+      - container.instance.delete
+      - container.instance.task.migrate_revert
+      - container.instance.task.migrate
+      # there may be other custom-generated container.instance events
+
+      - container.backup.create
+      - container.backup.restore
+      - container.backup.delete
+      - container.backup.task.delete
+      - container.backup.task.restore
+
+      - dns.zone.verify
+      - dns.zone.delete
+      - dns.zone.task.verify
+      - dns.zone.update
+      - dns.zone.task.delete
+      - dns.zone.create
+
+      - dns.zone.record.delete
+      - dns.zone.record.cert.generate
+      - dns.zone.record.cert.generate.auto
+      - dns.zone.record.task.cert.generate
+      - dns.zone.record.update
+      - dns.zone.record.task.delete
+      - dns.zone.record.create
+
+      - stack.update
+      - stack.task.delete
+      - stack.create
+      - stack.task.prune
+
+      - stack.build.create
+      - stack.build.generate
+      - stack.build.deploy
+      - stack.build.delete
+      - stack.build.task.delete
+      - stack.build.create
+      - stack.build.task.generate
+      - stack.build.task.deploy
+
+      - infrastructure.server.task.delete
+      - infrastructure.server.task.restart
+      - infrastructure.server.services.sftp.auth
+      - infrastructure.server.live
+      - infrastructure.server.delete
+      - infrastructure.server.restart
+      - infrastructure.server.compute.restart
+      - infrastructure.server.compute.spawner.restart
+      - infrastructure.server.reconfigure.features
+      - infrastructure.server.provision
+      - infrastructure.server.console
+      - infrastructure.server.update
+      - infrastructure.server.task.provision
+      - infrastructure.server.ssh.token
+      - infrastructure.server.task.reconfigure.features
+
+      - sdn.network.update
+      - sdn.network.task.delete
+      - sdn.network.create
+      - sdn.network.task.reconfigure
+
+      - pipeline.delete
+      - pipeline.trigger
+      - pipeline.update
+      - pipeline.task.delete
+      - pipeline.create
+      - pipeline.task.trigger
+
+      - pipeline.key.update
+      - pipeline.key.delete
+      - pipeline.key.create
+
+      - infrastructure.ips.pool.task.delete
   time:
     description: A timestamp for when the activity took place.
     "$ref": "../../DateTime.yml"

--- a/components/schemas/hubs/activity/ActivityMonitor.yml
+++ b/components/schemas/hubs/activity/ActivityMonitor.yml
@@ -1,0 +1,36 @@
+title: ActivityMonitor
+type: object
+description: Details related to the monitor that raised this activity event.
+required:
+  - level
+  - event
+  - state
+properties:
+  level:
+    type: string
+    description: |
+      The severity of the event.
+    enum:
+      - info
+      - low
+      - medium
+      - high
+      - critical
+  event:
+    type: string
+    description: How the platform has handled this monitor event.
+    enum:
+      - suggestion
+      - notice
+      - prevention
+      - detection
+      - reaction
+  state:
+    type: string
+    description: The current state of the monitored resource
+    enum:
+      - none
+      - unknown
+      - unreachable
+      - flux
+      - recovered

--- a/components/schemas/hubs/activity/ActivitySecurity.yml
+++ b/components/schemas/hubs/activity/ActivitySecurity.yml
@@ -1,0 +1,47 @@
+title: ActivitySecurity
+type: object
+description: Security information pertaining to this activity.
+required:
+  - risk
+  - surface
+  - event
+  - attack
+properties:
+  risk:
+    type: string
+    description: |
+      A risk level assessed by the platform. Depending on the nature of the incident, this may change even if the event type is the same.
+    enum:
+      - info
+      - low
+      - medium
+      - high
+      - critical
+  surface:
+    type: string
+    description: From where the platform has determined this security event originated from.
+    enum:
+      - network
+      - service
+      - fs
+      - api
+  event:
+    type: string
+    description: How the platform has handled this security event.
+    enum:
+      - suggestion
+      - notice
+      - prevention
+      - detection
+      - reaction
+  attack:
+    type: string
+    description: The type of attack the platform has determined has occurred.
+    enum:
+      - none
+      - auth-failure
+      - brute-force
+      - exploit-vulnerability
+      - social-engineer
+      - service-interruption
+      - access-elevation

--- a/components/schemas/hubs/activity/Session.yml
+++ b/components/schemas/hubs/activity/Session.yml
@@ -1,10 +1,10 @@
 title: ActivitySession
 type: object
 description: Session info about the activity entry.
-nullable: true
 required:
   - url
   - ip
+  - token
   - api_key
 properties:
   url:
@@ -13,6 +13,17 @@ properties:
   ip:
     type: string
     description: The IP of the account associated with the session.
+  token:
+    type: object
+    nullable: true
+    required:
+      - application_id
+      - application_capabilities_version
+    properties:
+      application_id:
+        $ref: ../../ID.yml
+      application_capabilities_version:
+        type: integer
   api_key:
     type: string
     description: The API key ID.

--- a/components/schemas/images/Image.yml
+++ b/components/schemas/images/Image.yml
@@ -64,7 +64,7 @@ properties:
         type: string
         description: The provider where this image is hosted.
       size:
-        type: string
+        type: integer
         description: The size of the image in bytes.
       file_name:
         type: string

--- a/components/schemas/images/Image.yml
+++ b/components/schemas/images/Image.yml
@@ -1,15 +1,14 @@
 title: Image
 type: object
-description: An Image Resource, which is a point in time build on a given image source.
+description: An image is a point in time build on a given image source, and what is distributed by Cycle to run containers.
 required:
   - id
   - hub_id
   - name
-  - stack
   - size
   - backend
+  - requires
   - factory
-  - tags
   - config
   - state
   - events
@@ -21,24 +20,6 @@ properties:
   name:
     type: string
     description: A user defined name for the image.
-  stack:
-    type: object
-    description: If the image is part of a stack, that information will be available here.
-    required:
-      - id
-      - build_id
-      - containers
-    properties:
-      id:
-        "$ref": "../ID.yml"
-      build_id:
-        type: string
-        description: A unique identifier for the build the image is assocaited with.
-      containers:
-        description: If this image is being used for any containers their identifiers are listed here.
-        type: array
-        items:
-          type: string
   size:
     type: integer
     description: The image size in bytes.
@@ -73,11 +54,21 @@ properties:
       file_id:
         type: string
         description: A file id for the image, used by the platform.
-  tags:
-    description: Tags that describe the version, package, or data about the image.
-    type: array
-    items:
-      type: string
+  requires:
+    type: object
+    description: Any restrictions or requirements needed to run this image as a container.
+    properties:
+      nvidia_gpu:
+        type: boolean
+  build:
+    type: object
+    description: Any additional build details for this image
+    properties:
+      args:
+        type: object
+        description: Arguments to pass to the factory during a build of this image.
+        additionalProperties:
+          type: string
   config:
     type: object
     description: Configuration settings for the image.

--- a/components/schemas/images/Image.yml
+++ b/components/schemas/images/Image.yml
@@ -214,11 +214,15 @@ properties:
     description: Identifies which factory the image was built on and when.
     required:
       - node_id
+      - cached
       - acknowledged
     properties:
       node_id:
         type: string
         description: The node holding the factory service that was responsible for building the image.
+      cached:
+        $ref: ../DateTime.yml
+        description: A date timestamp for when the node cached the image.
       acknowledged:
         $ref: ../DateTime.yml
         description: A date timestamp for when the node acknowledged the image import job.

--- a/components/schemas/images/Image.yml
+++ b/components/schemas/images/Image.yml
@@ -118,8 +118,10 @@ properties:
         additionalProperties:
           type: string
       labels:
-        type: string
+        type: object
         description: Image labels.
+        additionalProperties:
+          type: string
       command:
         description: The CMD array used to start the container.
         type: array

--- a/components/schemas/images/Image.yml
+++ b/components/schemas/images/Image.yml
@@ -86,7 +86,6 @@ properties:
       - env
       - labels
       - command
-      - onbuild
       - entrypoint
       - volumes
       - workdir
@@ -124,11 +123,6 @@ properties:
           type: string
       command:
         description: The CMD array used to start the container.
-        type: array
-        items:
-          type: string
-      onbuild:
-        description: Additional commands to run at build time.
         type: array
         items:
           type: string

--- a/components/schemas/images/Image.yml
+++ b/components/schemas/images/Image.yml
@@ -8,6 +8,7 @@ required:
   - size
   - backend
   - requires
+  - build
   - factory
   - config
   - state
@@ -62,6 +63,7 @@ properties:
         type: boolean
   build:
     type: object
+    nullable: true
     description: Any additional build details for this image
     properties:
       args:

--- a/components/schemas/images/Image.yml
+++ b/components/schemas/images/Image.yml
@@ -8,6 +8,7 @@ required:
   - stack
   - size
   - backend
+  - factory
   - tags
   - config
   - state
@@ -211,6 +212,7 @@ properties:
     "$ref": "../creators/CreatorScope.yml"
   factory:
     type: object
+    nullable: true
     description: Identifies which factory the image was built on and when.
     required:
       - node_id

--- a/components/schemas/images/Image.yml
+++ b/components/schemas/images/Image.yml
@@ -162,15 +162,40 @@ properties:
     required:
       - type
       - details
-    # TODO update with discrimantor based on selected type
     properties:
       type:
-        type: string
+        $ref: sources/ImageSourceType.yml
       details:
+        oneOf:
+          - type: object
+            required:
+              - id
+              - origin
+            properties:
+              id:
+                type: string
+              origin:
+                $ref: ./origins/ImageOrigin.yml
+          - type: object
+            required:
+              - id
+              - stack_id
+              - containers
+              - origin
+            properties:
+              id:
+                type: string
+              stack_id:
+                type: string
+              containers:
+                type: array
+                items:
+                  $ref: ../Identifier.yml
+              origin:
+                $ref: ./origins/ImageOrigin.yml
         type: object
         required:
           - id
-          - stack_id
           - origin
         properties:
           id:
@@ -179,6 +204,13 @@ properties:
             type: string
           origin:
             $ref: ./origins/ImageOrigin.yml
+      override:
+        type: object
+        properties:
+          target:
+            type: string
+          targz_url:
+            type: string
   creator:
     "$ref": "../creators/CreatorScope.yml"
   factory:

--- a/components/schemas/images/Image.yml
+++ b/components/schemas/images/Image.yml
@@ -157,7 +157,8 @@ properties:
         $ref: sources/ImageSourceType.yml
       details:
         oneOf:
-          - type: object
+          - title: BasicSource
+            type: object
             required:
               - id
               - origin
@@ -166,7 +167,8 @@ properties:
                 type: string
               origin:
                 $ref: ./origins/ImageOrigin.yml
-          - type: object
+          - title: StackSource
+            type: object
             required:
               - id
               - stack_id


### PR DESCRIPTION
This PR corrects a few issues in Hub Activity, including adding the missing properties `security` and `monitor`. I also cleaned up the spacing on the activity events enum to make it clearer and easier to read.