### PR TITLE
Update StackSpec struct appropriately

### DIFF
--- a/components/schemas/stacks/StackSource.yml
+++ b/components/schemas/stacks/StackSource.yml
@@ -4,8 +4,8 @@ description: A source for a stack to be created from.
 discriminator:
   propertyName: type
   mapping:
-    git-repo: ./spec/RepoSpec.yml
-    raw: ./spec/StackSpec.yml
+    git-repo: ./spec/StackRepoSource.yml
+    raw: ./spec/StackRawSource.yml
 oneOf:
-  - $ref: ./spec/RepoSpec.yml
-  - $ref: ./spec/StackSpec.yml
+  - $ref: ./spec/StackRepoSource.yml
+  - $ref: ./spec/StackRawSource.yml

--- a/components/schemas/stacks/spec/StackRawSource.yml
+++ b/components/schemas/stacks/spec/StackRawSource.yml
@@ -1,0 +1,13 @@
+title: StackRawSource
+type: object
+description: A stack spec resource.
+required:
+  - type
+  - details
+properties:
+  type:
+    type: string
+    enum:
+      - raw
+  details:
+    $ref: ./StackSpec.yml

--- a/components/schemas/stacks/spec/StackRepoSource.yml
+++ b/components/schemas/stacks/spec/StackRepoSource.yml
@@ -1,4 +1,4 @@
-title: StackRepoSourceType
+title: StackRepoSource
 type: object
 description: A repo source type for a stack.
 required:

--- a/components/schemas/stacks/spec/StackSpec.yml
+++ b/components/schemas/stacks/spec/StackSpec.yml
@@ -1,43 +1,30 @@
 title: StackSpec
 type: object
-description: A stack spec resource.
 required:
-  - type
-  - details
+  - version
+  - containers
 properties:
-  type:
+  version:
     type: string
-    enum:
-      - raw
-  details:
+    description: A string defining the version of the stack spec.
+  about:
     type: object
+    description: Information about the stack.
     required:
+      - description
       - version
-      - containers
     properties:
       version:
         type: string
-        description: A string defining the version of the stack spec.
-      about:
-        type: object
-        description: Information about the stack.
-        required:
-          - description
-          - version
-        properties:
-          version:
-            type: string
-            description: Internal version information set by the user.
-          description:
-            type: string
-            description: Information describing the stack.
-      containers:
-        nullable: true
-        type: array
-        items:
-          $ref: ./StackContainer.yml
-      annotations:
-        type: object
-        description: Additional meta info about the stack.
-        additionalProperties:
-          type: string
+        description: Internal version information set by the user.
+      description:
+        type: string
+        description: Information describing the stack.
+  containers:
+    nullable: true
+    $ref: ./StackContainer.yml
+  annotations:
+    type: object
+    description: Additional meta info about the stack.
+    additionalProperties:
+      type: string


### PR DESCRIPTION
StackSpec was improperly named.  It has been updated to StackRawSource.  StackSpec only refers to the details of StackRawsource.

RepoSource naming has been updated to match => StackRepoSource.

This naming convention is more descriptive and appropriately describes the struct.