### PR TITLE
Allow hub bililng tier/support IDs to be null

### DIFF
--- a/components/schemas/hubs/HubBillingProfile.yml
+++ b/components/schemas/hubs/HubBillingProfile.yml
@@ -27,9 +27,11 @@ properties:
     properties:
       tier_id:
         type: string
+        nullable: true
         description: An ID referencing the pricing tier applied to this hub.
       support_id:
         type: string
+        nullable: true
         description: An ID referencing the support plan applied to this hub.
   emails:
     type: array


### PR DESCRIPTION
There is a period of time where they may be null on new hub creation.