### PR TITLE
update reconfigureLoadbalancer config 

### DIFF
--- a/public/paths/environments/services/lb/tasks.yml
+++ b/public/paths/environments/services/lb/tasks.yml
@@ -41,6 +41,7 @@ post:
                   nullable: true
                   properties:
                     version:
+                      nullable: true
                       type: string
                       enum:
                         - v1


### PR DESCRIPTION
Update reconfigureLoadbalancer config to allow config.version to be null.  Null represents the platform default