### PR TITLE
update load balancer snapshots to be nullable

### DIFF
--- a/components/schemas/environments/services/lb/telemetry/LoadBalancerTelemetryReport.yml
+++ b/components/schemas/environments/services/lb/telemetry/LoadBalancerTelemetryReport.yml
@@ -12,6 +12,7 @@ properties:
     $ref: ../../../../Range.yml
   snapshots:
     type: array
+    nullable: true
     items:
       type: object
       title: LoadBalancerTelemetryReportMergedSnapshot


### PR DESCRIPTION
Load balancer telemetry is nullable and had been updated in the spec