### PR TITLE
Update load balancer to support new Cycle native load balancer

### DIFF
--- a/components/schemas/NullType.yml
+++ b/components/schemas/NullType.yml
@@ -1,4 +1,0 @@
-title: "OpenAPI 3.0 null-type ref"
-description: "for adding nullability to a ref"
-enum:
-  - null

--- a/components/schemas/NullType.yml
+++ b/components/schemas/NullType.yml
@@ -1,0 +1,3 @@
+title: "OpenAPI 3.0 null-type ref"
+description: "for adding nullability to a ref"
+enum: [null]

--- a/components/schemas/NullType.yml
+++ b/components/schemas/NullType.yml
@@ -1,3 +1,0 @@
-title: "OpenAPI 3.0 null-type ref"
-description: "for adding nullability to a ref"
-enum: [null]

--- a/components/schemas/NullType.yml
+++ b/components/schemas/NullType.yml
@@ -1,0 +1,4 @@
+title: "OpenAPI 3.0 null-type ref"
+description: "for adding nullability to a ref"
+enum:
+  - null

--- a/components/schemas/environments/services/LoadBalancerEnvironmentService.yml
+++ b/components/schemas/environments/services/LoadBalancerEnvironmentService.yml
@@ -22,7 +22,4 @@ properties:
       A boolean representing if this service container is set to high availability
       mode or not.
   config:
-    type: object
-    nullable: true
-    allOf:
-      - $ref: ./lb/LoadBalancerConfig.yml
+    $ref: ./lb/LoadBalancerConfig.yml

--- a/components/schemas/environments/services/lb/LoadBalancerConfig.yml
+++ b/components/schemas/environments/services/lb/LoadBalancerConfig.yml
@@ -1,44 +1,24 @@
 title: LoadBalancerConfig
 type: object
 description: The config object for the loadbalancer service.
-required:
-  - version
-  - haproxy
-  - ipv4
-  - ipv6
-properties:
-  version:
-    type: string
-    enum:
-      - haproxy
-      - v1
-  haproxy:
-    type: object
-    description: Describes settings that are passed to HAProxy within the load
-      balancer.
-    nullable: true
+discriminator:
+  propertyName: type
+  mapping:
+    haproxy: ../../../stacks/spec/services/loadbalancer/types/haproxy/HaProxyLbType.yml
+    v1: ../../../stacks/spec/services/loadbalancer/types/v1/V1LbType.yml
+    default: ../../../stacks/spec/services/loadbalancer/types/haproxy/HaProxyLbType.yml
+allOf:
+  - type: object
     required:
-      - default
-      - ports
+      - ipv4
+      - ipv6
     properties:
-      default:
-        allOf:
-          - description:
-              Settings that are applied to any port that is not overridden
-              in the following ports section.
-          - $ref: ../../../stacks/spec/services/loadbalancer/HaProxyConfig.yml
-      ports:
-        allOf:
-          - description:
-              An object that defines how HAProxy will act on a specific
-              port. The key is a custom port, and the value is the same settings
-              object found under `default` above.
-          - type: object
-            additionalProperties:
-              $ref: ../../../stacks/spec/services/loadbalancer/HaProxyConfig.yml
       ipv4:
         type: boolean
         description: Allow / disallow traffic to be routed via IPv4.
       ipv6:
         type: boolean
         description: Allow / disallow traffic to be routed via IPv6.
+  - oneOf:
+      - $ref: ../../../stacks/spec/services/loadbalancer/types/v1/V1LbType.yml
+      - $ref: ../../../stacks/spec/services/loadbalancer/types/haproxy/HaProxyLbType.yml

--- a/components/schemas/environments/services/lb/LoadBalancerConfig.yml
+++ b/components/schemas/environments/services/lb/LoadBalancerConfig.yml
@@ -7,7 +7,7 @@ discriminator:
   mapping:
     haproxy: ../../../stacks/spec/services/loadbalancer/types/haproxy/HaProxyLbType.yml
     v1: ../../../stacks/spec/services/loadbalancer/types/v1/V1LbType.yml
-    default: ../../../stacks/spec/services/loadbalancer/types/haproxy/HaProxyLbType.yml
+    default: ../../../stacks/spec/services/loadbalancer/types/DefaultLbType.yml
 allOf:
   - type: object
     required:
@@ -23,3 +23,4 @@ allOf:
   - oneOf:
       - $ref: ../../../stacks/spec/services/loadbalancer/types/v1/V1LbType.yml
       - $ref: ../../../stacks/spec/services/loadbalancer/types/haproxy/HaProxyLbType.yml
+      - $ref: ../../../stacks/spec/services/loadbalancer/types/DefaultLbType.yml

--- a/components/schemas/environments/services/lb/LoadBalancerConfig.yml
+++ b/components/schemas/environments/services/lb/LoadBalancerConfig.yml
@@ -1,6 +1,7 @@
 title: LoadBalancerConfig
 type: object
 description: The config object for the loadbalancer service.
+nullable: true
 discriminator:
   propertyName: type
   mapping:

--- a/components/schemas/images/Image.yml
+++ b/components/schemas/images/Image.yml
@@ -154,10 +154,11 @@ properties:
       mapping:
         stack-build: ./sources/StackImageSourceType.yml
         direct: ./sources/DirectImageSourceType.yml
-        bucket: ./sources/DirectImageSourceType.yml
+        bucket: ./sources/BucketImageSourceType.yml
     oneOf:
-      - $ref: ./sources/DirectImageSourceType.yml
-      - $ref: ./sources/StackImageSourceType.yml
+      - $ref: sources/DirectImageSourceType.yml
+      - $ref: sources/StackImageSourceType.yml
+      - $ref: sources/BucketImageSourceType.yml
   creator:
     "$ref": "../creators/CreatorScope.yml"
   factory:

--- a/components/schemas/images/sources/BucketImageSourceType.yml
+++ b/components/schemas/images/sources/BucketImageSourceType.yml
@@ -1,4 +1,4 @@
-title: DirectImageSource
+title: BucketImageSource
 type: object
 required:
   - id
@@ -7,7 +7,7 @@ properties:
   type:
     type: string
     enum:
-      - direct
+      - bucket
   details:
     type: object
     required:

--- a/components/schemas/stacks/spec/StackSpec.yml
+++ b/components/schemas/stacks/spec/StackSpec.yml
@@ -31,51 +31,7 @@ properties:
     type: object
     properties:
       loadbalancer:
-        type: object
-        properties:
-          haproxy:
-            type: object
-            properties:
-              haproxy:
-                type: object
-                nullable: true
-                required:
-                  - default
-                  - ports
-                properties:
-                  default:
-                    $ref: ../../stacks/spec/services/loadbalancer/HaProxyConfig.yml
-                  ports:
-                    type: object
-                    additionalProperties:
-                      $ref: ../../stacks/spec/services/loadbalancer/HaProxyConfig.yml
-          ipv4:
-            type: boolean
-          ipv6:
-            type: boolean
-          egress_gateways:
-            type: object
-            required:
-              - name
-              - destinations
-              - ports
-            properties:
-              name:
-                type: string
-              destinations:
-                type: array
-                items:
-                  type: string
-              ports:
-                type: object
-                required:
-                  - internal
-                  - external
-                properties:
-                  internal:
-                    type: integer
-                  external:
-                    type: integer
+        $ref: services/loadbalancer/StackSpecLoadBalancerConfig.yml
       vpn:
         type: object
         required:

--- a/components/schemas/stacks/spec/services/loadbalancer/StackSpecLoadBalancerConfig.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/StackSpecLoadBalancerConfig.yml
@@ -6,7 +6,7 @@ discriminator:
   mapping:
     haproxy: types/haproxy/HaProxyLbType.yml
     v1: types/v1/V1LbType.yml
-    default: types/haproxy/DefaultLbType.yml
+    default: types/DefaultLbType.yml
 allOf:
   - type: object
     required:

--- a/components/schemas/stacks/spec/services/loadbalancer/StackSpecLoadBalancerConfig.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/StackSpecLoadBalancerConfig.yml
@@ -6,7 +6,7 @@ discriminator:
   mapping:
     haproxy: types/haproxy/HaProxyLbType.yml
     v1: types/v1/V1LbType.yml
-    default: types/haproxy/HaProxyLbType.yml
+    default: types/haproxy/DefaultLbType.yml
 allOf:
   - type: object
     required:
@@ -24,3 +24,4 @@ allOf:
   - oneOf:
       - $ref: ./types/haproxy/HaProxyLbType.yml
       - $ref: ./types/v1/V1LbType.yml
+      - $ref: ./types/DefaultLbType.yml

--- a/components/schemas/stacks/spec/services/loadbalancer/StackSpecLoadBalancerConfig.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/StackSpecLoadBalancerConfig.yml
@@ -1,0 +1,26 @@
+title: StackSpecLoadBalancerConfig
+type: object
+description: The config object for the loadbalancer service.
+discriminator:
+  propertyName: type
+  mapping:
+    haproxy: types/haproxy/HaProxyLbType.yml
+    v1: types/v1/V1LbType.yml
+    default: types/haproxy/HaProxyLbType.yml
+allOf:
+  - type: object
+    required:
+      - ipv4
+      - ipv6
+    properties:
+      ipv4:
+        nullable: true
+        type: boolean
+        description: Allow / disallow traffic to be routed via IPv4.
+      ipv6:
+        nullable: true
+        type: boolean
+        description: Allow / disallow traffic to be routed via IPv6.
+  - oneOf:
+      - $ref: ./types/haproxy/HaProxyLbType.yml
+      - $ref: ./types/v1/V1LbType.yml

--- a/components/schemas/stacks/spec/services/loadbalancer/types/DefaultLbType.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/DefaultLbType.yml
@@ -1,0 +1,12 @@
+title: DefaultLbType
+type: object
+required:
+  - type
+  - details
+properties:
+  type:
+    type: string
+    enum:
+      - "default"
+  details:
+    $ref: haproxy/HaProxyConfig.yml

--- a/components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyConfig.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyConfig.yml
@@ -1,0 +1,21 @@
+type: object
+description: Describes settings that are passed to HAProxy within the load
+  balancer.
+required:
+  - default
+  - ports
+properties:
+  default:
+    allOf:
+      - description:
+          Settings that are applied to any port that is not overridden
+          in the following ports section.
+      - $ref: HaProxyConfigSet.yml
+  ports:
+    allOf:
+      - description: An object that defines how HAProxy will act on a specific
+          port. The key is a custom port, and the value is the same settings
+          object found under `default` above.
+      - type: object
+        additionalProperties:
+          $ref: HaProxyConfigSet.yml

--- a/components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyConfigSet.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyConfigSet.yml
@@ -1,4 +1,3 @@
----
 title: HAProxyConfig
 type: object
 required:

--- a/components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyLbType.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyLbType.yml
@@ -1,0 +1,12 @@
+title: HaProxyLbType
+type: object
+required:
+  - type
+  - details
+properties:
+  type:
+    type: string
+    enum:
+      - "haproxy"
+  details:
+    $ref: HaProxyConfig.yml

--- a/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfig.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfig.yml
@@ -1,0 +1,9 @@
+title: V1LbConfig
+type: object
+required:
+  - controllers
+properties:
+  controllers:
+    type: object
+    additionalProperties:
+      type: string

--- a/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfig.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfig.yml
@@ -6,4 +6,49 @@ properties:
   controllers:
     type: object
     additionalProperties:
-      type: string
+      title: V1LbController
+      type: object
+      required:
+        - identifier
+        - transport
+      properties:
+        identifier:
+          $ref: ../../../../../../Identifier.yml
+        transport:
+          title: V1LbControllerTransport
+          type: object
+          required:
+            - mode
+            - performance
+            - ingress
+            - timeouts
+            - routers
+          properties:
+            mode:
+              type: string
+              enum:
+                - tcp
+                - http
+            performance:
+              type: boolean
+            ingress:
+              type: object
+              required:
+                - port
+                - tls
+              properties:
+                port:
+                  type: integer
+                tls:
+                  type: boolean
+            timeouts:
+              type: object
+              required:
+                - idle
+              properties:
+                idle:
+                  type: integer
+            routers:
+              type: array
+              items:
+                $ref: V1LbConfigRouter.yml

--- a/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfigRouter.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfigRouter.yml
@@ -1,0 +1,38 @@
+title: V1LbConfigRouter
+type: object
+required:
+  - identifier
+  - mode
+  - config
+properties:
+  identifier:
+    type: string
+  mode:
+    type: string
+    enum:
+      - random
+      - round-robin
+  config:
+    type: object
+    required:
+      - performance
+      - sticky_sessions
+      - destination_retries
+      - transport
+      - timeouts
+    properties:
+      performance:
+        type: boolean
+      sticky_sessions:
+        type: boolean
+      destination_retries:
+        type: integer
+      transport:
+        type: object
+      timeouts:
+        type: object
+        required:
+          - idle
+        properties:
+          idle:
+            type: integer

--- a/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbType.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbType.yml
@@ -1,0 +1,12 @@
+title: V1LbType
+type: object
+required:
+  - type
+  - details
+properties:
+  type:
+    type: string
+    enum:
+      - "v1"
+  details:
+    $ref: V1LbConfig.yml

--- a/public/paths/environments/services/lb/tasks.yml
+++ b/public/paths/environments/services/lb/tasks.yml
@@ -35,9 +35,9 @@ post:
                 config:
                   type: object
                   allOf:
-                    - anyOf:
-                        - $ref: ../../../../../components/schemas/environments/services/lb/LoadBalancerConfig.yml
-                        - $ref: ../../../../../components/schemas/NullType.yml
+                    - type: object
+                      nullable: true
+                    - $ref: ../../../../../components/schemas/environments/services/lb/LoadBalancerConfig.yml
 
   responses:
     202:

--- a/public/paths/environments/services/lb/tasks.yml
+++ b/public/paths/environments/services/lb/tasks.yml
@@ -34,8 +34,10 @@ post:
                   description: A boolean where `true` represents the desire to run the environment load balancer service in high availability mode.
                 config:
                   type: object
-                  nullable: true
-                  $ref: ../../../../../components/schemas/environments/services/lb/LoadBalancerConfig.yml
+                  allOf:
+                    - anyOf:
+                        - $ref: ../../../../../components/schemas/environments/services/lb/LoadBalancerConfig.yml
+                        - $ref: ../../../../../components/schemas/NullType.yml
 
   responses:
     202:

--- a/public/paths/environments/services/lb/tasks.yml
+++ b/public/paths/environments/services/lb/tasks.yml
@@ -28,16 +28,14 @@ post:
               description: The name of the action to perform.
             contents:
               type: object
+              required:
+                - high_availability
               properties:
                 high_availability:
                   type: boolean
                   description: A boolean where `true` represents the desire to run the environment load balancer service in high availability mode.
                 config:
-                  type: object
-                  allOf:
-                    - type: object
-                      nullable: true
-                    - $ref: ../../../../../components/schemas/environments/services/lb/LoadBalancerConfig.yml
+                  $ref: ../../../../../components/schemas/environments/services/lb/LoadBalancerConfig.yml
 
   responses:
     202:

--- a/public/paths/environments/services/lb/tasks.yml
+++ b/public/paths/environments/services/lb/tasks.yml
@@ -32,6 +32,7 @@ post:
                 - high_availability
               properties:
                 high_availability:
+                  nullable: true
                   type: boolean
                   description: A boolean where `true` represents the desire to run the environment load balancer service in high availability mode.
                 config:

--- a/public/paths/environments/services/lb/tasks.yml
+++ b/public/paths/environments/services/lb/tasks.yml
@@ -36,40 +36,9 @@ post:
                   type: boolean
                   description: A boolean where `true` represents the desire to run the environment load balancer service in high availability mode.
                 config:
-                  type: object
-                  description: The config object for the loadbalancer service.
-                  nullable: true
-                  properties:
-                    version:
-                      nullable: true
-                      type: string
-                      enum:
-                        - v1
-                        - haproxy
-                    ipv4:
-                      type: boolean
-                      nullable: true
-                      description: Allow / disallow traffic to be routed via IPv4.
-                    ipv6:
-                      type: boolean
-                      nullable: true
-                      description: Allow / disallow traffic to be routed via IPv6.
-                    haproxy:
-                      type: object
-                      description:
-                        Describes settings that are passed to HAProxy within the load
-                        balancer.
-                      nullable: true
-                      required:
-                        - default
-                        - ports
-                      properties:
-                        default:
-                          $ref: ../../../../../components/schemas/stacks/spec/services/loadbalancer/HaProxyConfig.yml
-                        ports:
-                          type: object
-                          additionalProperties:
-                            $ref: ../../../../../components/schemas/stacks/spec/services/loadbalancer/HaProxyConfig.yml
+                  anyOf:
+                    - $ref: ../../../../../components/schemas/NullType.yml
+                    - $ref: ../../../../../components/schemas/environments/services/lb/LoadBalancerConfig.yml
 
   responses:
     202:

--- a/public/paths/environments/services/lb/tasks.yml
+++ b/public/paths/environments/services/lb/tasks.yml
@@ -36,8 +36,9 @@ post:
                   type: boolean
                   description: A boolean where `true` represents the desire to run the environment load balancer service in high availability mode.
                 config:
-                  anyOf:
-                    - $ref: ../../../../../components/schemas/NullType.yml
+                  type: object
+                  nullable: true
+                  allOf:
                     - $ref: ../../../../../components/schemas/environments/services/lb/LoadBalancerConfig.yml
 
   responses:

--- a/public/paths/environments/services/lb/tasks.yml
+++ b/public/paths/environments/services/lb/tasks.yml
@@ -29,17 +29,13 @@ post:
             contents:
               type: object
               properties:
-                customize:
-                  type: boolean
-                  description: Boolean that sets custom vs default VPN configuration
                 high_availability:
                   type: boolean
                   description: A boolean where `true` represents the desire to run the environment load balancer service in high availability mode.
                 config:
                   type: object
                   nullable: true
-                  allOf:
-                    - $ref: ../../../../../components/schemas/environments/services/lb/LoadBalancerConfig.yml
+                  $ref: ../../../../../components/schemas/environments/services/lb/LoadBalancerConfig.yml
 
   responses:
     202:


### PR DESCRIPTION
Updates the load balancer config to support the changes necessary for the new Cycle native load balancer that is being released soon. 

This is a breaking change and contains updates that are not yet deployed to production. If you're generating production tools off of this spec, please use the official release tags.