### PR TITLE
Add image extension to container

### DIFF
--- a/components/schemas/containers/summaries/ImageSummary.yml
+++ b/components/schemas/containers/summaries/ImageSummary.yml
@@ -1,9 +1,25 @@
 title: ContainerImageSummary
 description: A summary of the image this container was created from.
 type: object
+required:
+  - id
+  - service
+  - extension
 properties:
   id:
-    "$ref": "../../ID.yml"
+    type: string
+    nullable: true
+    allOf:
+      - $ref: "../../ID.yml"
+  extension:
+    type: object
+    description: An image that is packaged with Cycle directly, such as the global load balancer.
+    nullable: true
+    required:
+      - identifier
+    properties:
+      identifier:
+        $ref: ../../Identifier.yml
   service:
     type: string
     nullable: true


### PR DESCRIPTION
Adds support for a container image summary to indicate an 'extension' - an image that is optionally able to be deployed, but is hosted and maintained by Cycle. This will be utilized for certain new functionality, such as the global load balancer.