### PR TITLE
Make LB types nullable

### DIFF
--- a/components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyLbType.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyLbType.yml
@@ -9,4 +9,7 @@ properties:
     enum:
       - "haproxy"
   details:
-    $ref: HaProxyConfig.yml
+    type: object
+    nullable: true
+    allOf:
+      - $ref: HaProxyConfig.yml

--- a/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbType.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbType.yml
@@ -9,4 +9,7 @@ properties:
     enum:
       - "v1"
   details:
-    $ref: V1LbConfig.yml
+    type: object
+    nullable: true
+    allOf:
+      - $ref: V1LbConfig.yml


### PR DESCRIPTION
Adds support for load balancer details to be nullable,  which will occur if there is no custom configuration applied.