### PR TITLE
Create duration string type

### DIFF
--- a/components/schemas/Duration.yml
+++ b/components/schemas/Duration.yml
@@ -1,0 +1,4 @@
+title: Duration
+type: string
+description: A string signifying a duration of time. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h", "d", "w", "y".
+example: 72h45m2s

--- a/components/schemas/containers/config/ContainerDeploy.yml
+++ b/components/schemas/containers/config/ContainerDeploy.yml
@@ -56,8 +56,8 @@ properties:
       - signals
     properties:
       graceful_timeout:
-        type: integer
-        description: The time in seconds the platform will wait for a container to stop gracefully.
+        $ref: ../../Duration.yml
+        description: How long the platform will wait for a container to stop gracefully.
       signals:
         type: array
         items:
@@ -75,8 +75,8 @@ properties:
     description: Configurations for container startup.
     properties:
       delay:
-        type: integer
-        description: A value in seconds representing how long the platform will wait before sending the start signal to the given container.
+        $ref: ../../Duration.yml
+        description: How long the platform will wait before sending the start signal to the given container.
   restart:
     type: object
     description: Configurations for container restart events.
@@ -93,8 +93,8 @@ properties:
           - never
           - failure
       delay:
-        type: integer
-        description: Time in seconds the platform will wait before trying to restart the container.
+        $ref: ../../Duration.yml
+        description: How long the platform will wait before trying to restart the container.
       max_attempts:
         type: integer
         description: The amount of times the platform will attempt the restart policies.
@@ -115,11 +115,11 @@ properties:
         type: integer
         description: The number of times the platform will retry the command before marking the container unhealthy.
       interval:
-        type: integer
-        description: The number of seconds between retries.
+        $ref: ../../Duration.yml
+        description: How long to wait between restarts.
       timeout:
-        type: integer
-        description: The number of time in seconds before a health check attempt times out.
+        $ref: ../../Duration.yml
+        description: How long before a health check attempt times out.
       restart:
         type: boolean
         description: A boolean where `true` represents the desire for a container to restart if unhealthy.
@@ -132,11 +132,11 @@ properties:
       - disable
     properties:
       retention:
-        type: integer
-        description: The number in seconds for telemetry data to be retained.
+        $ref: ../../Duration.yml
+        description: How long telemetry data should be retained.
       interval:
-        type: integer
-        description: The number in seconds between samples.
+        $ref: ../../Duration.yml
+        description: The duration between samples.
       disable:
         type: boolean
         description: A boolean where true disables all telemetry reporting for this container.

--- a/components/schemas/containers/config/ContainerIntegrations.yml
+++ b/components/schemas/containers/config/ContainerIntegrations.yml
@@ -86,9 +86,11 @@ properties:
             type: string
             description: The command to run for the backup.
           timeout:
-            $ref: ../../Duration.yml
-            description: How long the backup will attempt to run before timing out.
+            type: string
             nullable: true
+            description: How long the backup will attempt to run before timing out.
+            allOf:
+              - $ref: ../../Duration.yml
           cron_string:
             type: string
             description: A cron string that configures how often the backup will run.
@@ -105,7 +107,7 @@ properties:
           timeout:
             type: string
             nullable: true
-            description: The time in seconds for the restore to appempt to complete before timing out.
+            description: The time in seconds for the restore to attempt to complete before timing out.
             allOf:
               - $ref: ../../Duration.yml
       retention:

--- a/components/schemas/containers/config/ContainerIntegrations.yml
+++ b/components/schemas/containers/config/ContainerIntegrations.yml
@@ -86,8 +86,8 @@ properties:
             type: string
             description: The command to run for the backup.
           timeout:
-            type: integer
-            description: The time in seconds for the backup to attempt to run before timing out.
+            $ref: ../../Duration.yml
+            description: How long the backup will attempt to run before timing out.
             nullable: true
           cron_string:
             type: string
@@ -103,11 +103,15 @@ properties:
             type: string
             description: The command to run for restoring from a backup.
           timeout:
-            type: integer
+            type: string
             nullable: true
             description: The time in seconds for the restore to appempt to complete before timing out.
+            allOf:
+              - $ref: ../../Duration.yml
       retention:
-        type: integer
+        type: string
         nullable: true
-        description: How long (in seconds) to keep backups. Default is 1 year.
-        default: 31536000
+        description: How long the platform will keep backups. Default is 1 year.
+        allOf:
+          - $ref: ../../Duration.yml
+        default: "365d"

--- a/components/schemas/pipelines/steps/SleepStep.yml
+++ b/components/schemas/pipelines/steps/SleepStep.yml
@@ -21,6 +21,6 @@ properties:
   details:
     type: object
     properties:
-      seconds:
-        type: integer
-        description: Total duration (seconds) to run this step for, before moving on to the next step.
+      duration:
+        description: Total duration to run this step for, before moving on to the next step.
+        $ref: ../../Duration.yml

--- a/components/schemas/stacks/spec/StackContainerConfigDeploy.yml
+++ b/components/schemas/stacks/spec/StackContainerConfigDeploy.yml
@@ -57,8 +57,11 @@ properties:
     type: object
     properties:
       graceful_timeout:
+        type: string
         nullable: true
-        type: integer
+        description: How long the platform will wait for a container to stop gracefully.
+        allOf:
+          - $ref: ../../Duration.yml
       signals:
         type: array
         items:
@@ -68,7 +71,10 @@ properties:
     properties:
       delay:
         nullable: true
-        type: integer
+        type: string
+        description: How long the platform will wait before sending the start signal to the given container.
+        allOf:
+          - $ref: ../../Duration.yml
   restart:
     type: object
     required:
@@ -83,7 +89,8 @@ properties:
           - never
           - failure
       delay:
-        type: integer
+        $ref: ../../Duration.yml
+        description: How long the platform will wait before trying to restart the container.
       max_attempts:
         type: integer
       notify:
@@ -109,9 +116,11 @@ properties:
       retries:
         type: integer
       interval:
-        type: integer
+        $ref: ../../Duration.yml
+        description: How long to wait between restarts.
       timeout:
-        type: integer
+        $ref: ../../Duration.yml
+        description: How long before a health check attempt times out.
       restart:
         type: boolean
   telemetry:
@@ -122,8 +131,10 @@ properties:
       - disable
     properties:
       retention:
-        type: integer
+        $ref: ../../Duration.yml
+        description: How long telemetry data should be retained.
       interval:
-        type: integer
+        $ref: ../../Duration.yml
+        description: The duration between samples.
       disable:
         type: boolean

--- a/components/schemas/stacks/spec/StackContainerConfigIntegrations.yml
+++ b/components/schemas/stacks/spec/StackContainerConfigIntegrations.yml
@@ -64,8 +64,11 @@ properties:
           command:
             type: string
           timeout:
+            type: string
             nullable: true
-            type: integer
+            description: How long the backup will attempt to run before timing out.
+            allOf:
+              - $ref: ../../Duration.yml
           cron_string:
             nullable: true
             type: string
@@ -79,8 +82,15 @@ properties:
           command:
             type: string
           timeout:
+            type: string
             nullable: true
-            type: integer
+            description: The time in seconds for the restore to attempt to complete before timing out.
+            allOf:
+              - $ref: ../../Duration.yml
       retention:
-        type: integer
+        type: string
         nullable: true
+        description: How long the platform will keep backups. Default is 1 year.
+        allOf:
+          - $ref: ../../Duration.yml
+        default: "365d"


### PR DESCRIPTION
The platform API is standardizing what were once ambiguous integer durations into a more human-friendly string. This PR updates our types to match that new string where required.