### PR TITLE
Add 'existing' type to image sources

### DIFF
--- a/components/schemas/images/origins/ExistingSource.yml
+++ b/components/schemas/images/origins/ExistingSource.yml
@@ -1,0 +1,7 @@
+title: ExistingSource
+type: object
+description: In a stack, specifies an image source ID from which Cycle will derive any values not specified in the stack file. This is useful for avoiding direct placement of credentials in a stack file, for example.
+properties:
+  source_id:
+    $ref: ../../ID.yml
+    description: The ID of the image source this image should be built from.

--- a/components/schemas/images/origins/dockerFile/DockerFileOrigin.yml
+++ b/components/schemas/images/origins/dockerFile/DockerFileOrigin.yml
@@ -9,6 +9,8 @@ properties:
   details:
     type: object
     properties:
+      existing:
+        $ref: ../ExistingSource.yml
       # TODO toggle between repo / tarball
       repo:
         "$ref": "./RepoType.yml"

--- a/components/schemas/images/origins/dockerHub/DockerHubOrigin.yml
+++ b/components/schemas/images/origins/dockerHub/DockerHubOrigin.yml
@@ -11,6 +11,8 @@ properties:
     required:
       - target
     properties:
+      existing:
+        $ref: ../ExistingSource.yml
       target:
         type: string
         description: The DockerHub target string. ex - `mysql:5.7`

--- a/components/schemas/images/origins/dockerRegistry/DockerRegistryOrigin.yml
+++ b/components/schemas/images/origins/dockerRegistry/DockerRegistryOrigin.yml
@@ -12,6 +12,8 @@ properties:
       - target
       - url
     properties:
+      existing:
+        $ref: ../ExistingSource.yml
       target:
         type: string
         description: The image name on the registry.


### PR DESCRIPTION
Adds the 'existing' type field to relevant image sources, allowing someone to 'inject' image source details into their stack at build time from an existing Cycle image source. This is useful for keeping registry credentials out of a stack file, for example.