### PR TITLE
add environment.services.vpn.login to activity list

### DIFF
--- a/components/schemas/hubs/activity/Activity.yml
+++ b/components/schemas/hubs/activity/Activity.yml
@@ -132,6 +132,7 @@ properties:
       - environment.services.lb.task.reconfigure
       - environment.services.vpn.task.reconfigure
       - environment.vpn.user.create
+      - environment.services.vpn.login
       - environment.task.initialize
       - environment.task.start
       - environment.task.stop


### PR DESCRIPTION
Adds a missing activity type to the list, `environment.services.vpn.login`