### PR TITLE
Add cpu load to server stats and telemetry

### DIFF
--- a/components/schemas/infrastructure/stats/ServerStatsCpu.yml
+++ b/components/schemas/infrastructure/stats/ServerStatsCpu.yml
@@ -18,3 +18,5 @@ properties:
         speed:
           type: integer
           description: The speed of the processor.
+  usage:
+    $ref: ./ServerStatsCpuUsage.yml

--- a/components/schemas/infrastructure/stats/ServerStatsCpuUsage.yml
+++ b/components/schemas/infrastructure/stats/ServerStatsCpuUsage.yml
@@ -2,22 +2,22 @@ title: ServerStatsCpuUsage
 type: object
 properties:
   user:
-    type: number
+    type: integer
   nice:
-    type: number
+    type: integer
   system:
-    type: number
+    type: integer
   idle:
-    type: number
+    type: integer
   iowait:
-    type: number
+    type: integer
   irq:
-    type: number
+    type: integer
   soft_irq:
-    type: number
+    type: integer
   steal:
-    type: number
+    type: integer
   guest:
-    type: number
+    type: integer
   guest_nice:
-    type: number
+    type: integer

--- a/components/schemas/infrastructure/stats/ServerStatsCpuUsage.yml
+++ b/components/schemas/infrastructure/stats/ServerStatsCpuUsage.yml
@@ -1,0 +1,23 @@
+title: ServerStatsCpuUsage
+type: object
+properties:
+  user:
+    type: number
+  nice:
+    type: number
+  system:
+    type: number
+  idle:
+    type: number
+  iowait:
+    type: number
+  irq:
+    type: number
+  soft_irq:
+    type: number
+  steal:
+    type: number
+  guest:
+    type: number
+  guest_nice:
+    type: number

--- a/components/schemas/infrastructure/stats/ServerStatsTelemetry.yml
+++ b/components/schemas/infrastructure/stats/ServerStatsTelemetry.yml
@@ -11,6 +11,8 @@ properties:
   time:
     description: The timestamp for when the telemetery data was collected.
     "$ref": "../../DateTime.yml"
+  cpu_usage:
+    $ref: ./ServerStatsCpuUsage.yml
   load:
     "$ref": "./ServerStatsLoad.yml"
   ram:


### PR DESCRIPTION
Added CPU Server Stats.  Available in the server.meta and telemetry.cpu_usage sections
