### PR TITLE
Add oci-registry type image origin

### DIFF
--- a/components/schemas/images/origins/ImageOrigin.yml
+++ b/components/schemas/images/origins/ImageOrigin.yml
@@ -4,16 +4,18 @@ description: The origin of the given image source.
 discriminator:
   propertyName: type
   mapping:
-    docker-hub: ./dockerHub/DockerHubOrigin.yml
-    docker-file: ./dockerFile/DockerFileOrigin.yml
-    docker-registry: ./dockerRegistry/DockerRegistryOrigin.yml
-    cycle-upload: ./cycleUpload/CycleUploadOrigin.yml
-    cycle-source: ./cycleSource/CycleSourceOrigin.yml
-    none: ./none/NoneOrigin.yml
+    docker-hub: dockerHub/DockerHubOrigin.yml
+    docker-file: dockerFile/DockerFileOrigin.yml
+    docker-registry: dockerRegistry/DockerRegistryOrigin.yml
+    oci-registry: ociRegistry/OciRegistryOrigin.yml
+    cycle-upload: cycleUpload/CycleUploadOrigin.yml
+    cycle-source: cycleSource/CycleSourceOrigin.yml
+    none: none/NoneOrigin.yml
 oneOf:
-  - $ref: ./dockerHub/DockerHubOrigin.yml
-  - $ref: ./dockerFile/DockerFileOrigin.yml
-  - $ref: ./dockerRegistry/DockerRegistryOrigin.yml
-  - $ref: ./cycleUpload/CycleUploadOrigin.yml
-  - $ref: ./cycleSource/CycleSourceOrigin.yml
+  - $ref: dockerHub/DockerHubOrigin.yml
+  - $ref: dockerFile/DockerFileOrigin.yml
+  - $ref: dockerRegistry/DockerRegistryOrigin.yml
+  - $ref: ociRegistry/OciRegistryOrigin.yml
+  - $ref: cycleUpload/CycleUploadOrigin.yml
+  - $ref: cycleSource/CycleSourceOrigin.yml
   - $ref: none/NoneOrigin.yml

--- a/components/schemas/images/origins/auth/RegistryAuth.yml
+++ b/components/schemas/images/origins/auth/RegistryAuth.yml
@@ -1,0 +1,13 @@
+title: RegistryAuth
+type: object
+description: Authentication details for a third party image registry/source.
+discriminator:
+  propertyName: type
+  mapping:
+    user: ./RegistryAuthUser.yml
+    provider: ./RegistryAuthProvider.yml
+    webhook: ./RegistryAuthWebhook.yml
+oneOf:
+  - $ref: ./RegistryAuthUser.yml
+  - $ref: ./RegistryAuthProvider.yml
+  - $ref: ./RegistryAuthWebhook.yml

--- a/components/schemas/images/origins/auth/RegistryAuthProvider.yml
+++ b/components/schemas/images/origins/auth/RegistryAuthProvider.yml
@@ -1,0 +1,40 @@
+title: RegistryAuthProvider
+description: Credentials for authentication to a provider-native image registry, such as AWS ECR.
+type: object
+required:
+  - type
+  - details
+properties:
+  type:
+    type: string
+    enum:
+      - provider
+  details:
+    type: object
+    required:
+      - flavor
+      - credentials
+    properties:
+      flavor:
+        type: string
+        enum:
+          - ecr
+      credentials:
+        title: RegistryAuthProviderCredentials
+        type: object
+        properties:
+          region:
+            type: string
+          namespace:
+            type: string
+          api_key:
+            type: string
+          secret:
+            type: string
+          subscription_id:
+            type: string
+          client_id:
+            type: string
+          config:
+            type: string
+            description: A base64'd string of additional configuration options.

--- a/components/schemas/images/origins/auth/RegistryAuthUser.yml
+++ b/components/schemas/images/origins/auth/RegistryAuthUser.yml
@@ -1,0 +1,18 @@
+title: RegistryAuthUser
+description: User/token based credentials for authentication to a third-party image source.
+type: object
+required:
+  - type
+  - details
+properties:
+  type:
+    type: string
+    enum:
+      - user
+  details:
+    type: object
+    properties:
+      username:
+        type: string
+      token:
+        type: string

--- a/components/schemas/images/origins/auth/RegistryAuthWebhook.yml
+++ b/components/schemas/images/origins/auth/RegistryAuthWebhook.yml
@@ -1,0 +1,18 @@
+title: RegistryAuthWebhook
+description: Webhook-based authentication to the provided URL. This webhook expects to receive a base-64 string that when decoded is in the format `username:password`
+type: object
+required:
+  - type
+  - details
+properties:
+  type:
+    type: string
+    enum:
+      - webhook
+  details:
+    type: object
+    required:
+      - url
+    properties:
+      url:
+        type: string

--- a/components/schemas/images/origins/ociRegistry/OciRegistryOrigin.yml
+++ b/components/schemas/images/origins/ociRegistry/OciRegistryOrigin.yml
@@ -1,0 +1,27 @@
+title: OciRegistryOrigin
+type: object
+description: An image origin that pulls images fro an OCI-compatible registry. Also used for provider-native registries, such as AWS ECR.
+properties:
+  type:
+    type: string
+    enum:
+      - oci-registry
+  details:
+    type: object
+    required:
+      - target
+      - url
+    properties:
+      existing:
+        $ref: ../ExistingSource.yml
+      target:
+        type: string
+        description: The image name on the registry.
+      url:
+        type: string
+        description: The url of the remote registry.
+      auth:
+        allOf:
+          - type: object
+            nullable: true
+          - $ref: ../auth/RegistryAuth.yml

--- a/components/schemas/infrastructure/providers/NativeProviderIdentifier.yml
+++ b/components/schemas/infrastructure/providers/NativeProviderIdentifier.yml
@@ -1,12 +1,3 @@
 title: NativeProviderIdentifier
 type: string
-description: An identifier for the provider
-enum:
-  - equinix-metal
-  - coreweave
-  - vultr
-  - hivelocity
-  - aws
-  - azure
-  - gcp
-  - digitalocean
+description: An identifier for a native Cycle provider.


### PR DESCRIPTION
Adds the upcoming OCI Registry type origin, which will be coming to the platform soon. This type enables provider-native integrations to 3rd party registries such as AWS ECR.