### PR TITLE
Fix environment.vpn.user.create -> environment.service.vpn.user.create

### DIFF
--- a/components/schemas/hubs/activity/Activity.yml
+++ b/components/schemas/hubs/activity/Activity.yml
@@ -131,7 +131,7 @@ properties:
       - environment.services.discovery.task.reconfigure
       - environment.services.lb.task.reconfigure
       - environment.services.vpn.task.reconfigure
-      - environment.vpn.user.create
+      - environment.services.vpn.user.create
       - environment.services.vpn.login
       - environment.task.initialize
       - environment.task.start


### PR DESCRIPTION
Corrects an issue with the name of one of the activity events.