### PR TITLE
Fix events filter description on hub activity

### DIFF
--- a/public/paths/hubs/activity.yml
+++ b/public/paths/hubs/activity.yml
@@ -65,7 +65,7 @@ get:
           events:
             type: string
             description: |
-              `filter[events]=value` filter by event names. Example: `filter[event]=environment.services.vpn.login`
+              `filter[events]=value` filter by event names. Example: `filter[events]=environment.services.vpn.login`
           verbosity:
             type: integer
             description: |


### PR DESCRIPTION
Fixes the example for how to use the hub activity "events" filter.