### PR TITLE
Add forward scheme to v1 router

### DIFF
--- a/components/schemas/stacks/spec/services/loadbalancer/types/v1/routers/HttpRouterConfig.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/v1/routers/HttpRouterConfig.yml
@@ -41,3 +41,15 @@ properties:
             nullable: true
             type: string
             description: A specific URL to redirect to.
+      forward:
+        nullable: true
+        type: object
+        required:
+          - scheme
+        properties:
+          scheme:
+            nullable: true
+            type: string
+            enum:
+              - tcp
+              - http


### PR DESCRIPTION
Adds the missing forward scheme option to v1 routers.