### PR TITLE
add duration to lbConfigRouter destination connection timeout

### DIFF
--- a/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfigRouter.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfigRouter.yml
@@ -55,6 +55,7 @@ properties:
         properties:
           destination_connection:
             description: The duration the load balancer will wait before timing out while attempting to connect to the destination.
+            $ref: ../../../../../../Duration.yml
       extension:
         type: object
         description: Additional configuration options specific to the selected mode (tcp/http).


### PR DESCRIPTION
lbConfigRouter timeout.destination_connection was not assigned a type.  This was updated to properly reflect a duration string.