### PR TITLE
Add nullable instance health state & health_check delay field

### DIFF
--- a/components/schemas/containers/config/ContainerDeploy.yml
+++ b/components/schemas/containers/config/ContainerDeploy.yml
@@ -114,6 +114,9 @@ properties:
       retries:
         type: integer
         description: The number of times the platform will retry the command before marking the container unhealthy.
+      delay:
+        $ref: ../../Duration.yml
+        description: How long to wait before performing an initial health check when the instance starts. The `state.health.healthy` field of the instance will be `null`` until the first check is performed.
       interval:
         $ref: ../../Duration.yml
         description: How long to wait between restarts.

--- a/components/schemas/containers/instances/InstanceState.yml
+++ b/components/schemas/containers/instances/InstanceState.yml
@@ -20,6 +20,7 @@ allOf:
           - deleted
       health:
         type: object
+        nullable: true
         description: information about the health of the instance.
         required:
           - healthy
@@ -27,7 +28,12 @@ allOf:
         properties:
           healthy:
             type: boolean
-            description: A boolean where true represents the instance being healthy.
+            nullable: true
+            description: |
+              Describes the healthiness of the instance. Health checks can be configured at the container level. 
+              - `true`: The instance is considered healthy.
+              - `false`: The instance is considered unhealthy.
+              - `null`: The instance has not yet reported its health, or a health check has not yet been performed.
           updated:
             description: A timestamp of the last time the instance health was updated.
             "$ref": "../../DateTime.yml"


### PR DESCRIPTION
Adds new health check properties being implemented in the platform. 

- On an instance, `state.health.healthy` is now nullable, implying the first health check has not yet been performed
- Added a `delay` field to the container deploy -> health_check config. This duration tells Cycle how long to wait before performing an initial health check (to give sufficient time for the container instance to start before falsely responding).
- Corrects a mistake where instance `state.health` is actually nullable.