### PR TITLE
Providers identifier

### DIFF
--- a/public/paths/infrastructure/providers/locations.yml
+++ b/public/paths/infrastructure/providers/locations.yml
@@ -4,7 +4,7 @@ get:
     - Providers
   parameters:
     - name: providerId
-      description: The ID for the given provider.
+      description: The identifier for the given provider. Can be `aws`, `gcp`, `equinix-metal`, `vultr`.
       in: path
       required: true
       schema:

--- a/public/paths/infrastructure/providers/servers.yml
+++ b/public/paths/infrastructure/providers/servers.yml
@@ -4,7 +4,7 @@ get:
     - Providers
   parameters:
     - name: providerId
-      description: The ID for the given provider.
+      description: The identifier for the given provider. Can be `aws`, `gcp`, `equinix-metal`, `vultr`.
       in: path
       required: true
       schema:


### PR DESCRIPTION
Calls using a define "providerId" can be either the ID of the provider or the identifier.  This pull request has tested all calls using providerId as a URL param and updated the descriptions of the calls that use the identifier (as opposed to the actual ID). 