### PR TITLE
renamed resetPassword to updatePassword and added reset-password route

### DIFF
--- a/public/api.yml
+++ b/public/api.yml
@@ -115,7 +115,9 @@ paths:
   "/v1/account/logins":
     "$ref": "./paths/accounts/logins.yml"
   "/v1/account/password":
-    "$ref": "./paths/accounts/password.yml"
+    "$ref": "./paths/accounts/updatePassword.yml"
+  "/v1/account/reset-password":
+    "$ref": "./paths/accounts/resetPassword.yml"
   "/v1/account/2fa/setup":
     "$ref": "./paths/accounts/twoFa/setup.yml"
   "/v1/account/2fa/disable":

--- a/public/paths/accounts/resetPassword.yml
+++ b/public/paths/accounts/resetPassword.yml
@@ -1,0 +1,52 @@
+post:
+  operationId: "resetPassword"
+  security:
+    - bearerAuth: []
+  tags:
+    - Accounts
+  summary: Update Account Invite
+  description: Update a given invite.
+  requestBody:
+    description: Req body for updating account invite
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - type: object
+              required:
+                - email
+              properties:
+                email:
+                  type: object
+                  required:
+                    - address
+                  properties:
+                    address:
+                      type: string
+            - type: object
+              required:
+                - token
+                - password
+              properties:
+                token:
+                  type: string
+                password:
+                  type: string
+  responses:
+    200:
+      description: Returns success true
+      content:
+        application/json:
+          schema:
+            title: "ResetPasswordApiResponse"
+            type: object
+            properties:
+              data:
+                type: object
+                required:
+                  - success
+                properties:
+                  success:
+                    type: boolean
+    default:
+      $ref: ../../../components/responses/errors/DefaultError.yml

--- a/public/paths/accounts/updatePassword.yml
+++ b/public/paths/accounts/updatePassword.yml
@@ -1,5 +1,5 @@
 patch:
-  operationId: "resetPassword"
+  operationId: "updatePassword"
   security:
     - bearerAuth: []
   tags:
@@ -25,7 +25,7 @@ patch:
       content:
         application/json:
           schema:
-            title: "ResetPasswordApiResponse"
+            title: "UpdatePasswordApiResponse"
             type: object
             properties:
               data:


### PR DESCRIPTION
Update password was incorrectly named "resetPassword".  This call is used if the user knows their password and wants to update it.

Changed the name of the updatePassword route and added the missing "account/reset-password" route which is necessary for updating a forgotten password.