### PR TITLE
Add auto-scale group as activity component include

### DIFF
--- a/components/schemas/includes/ComponentsIncludes.yml
+++ b/components/schemas/includes/ComponentsIncludes.yml
@@ -25,3 +25,4 @@ additionalProperties:
     - $ref: ../hubs/Hub.yml
     - $ref: ../billing/invoices/Invoice.yml
     - $ref: ../billing/methods/Method.yml
+    - $ref: ../infrastructure/auto-scale/groups/AutoScaleGroup.yml


### PR DESCRIPTION
Adds the auto-scale group as a possible included component value for activity log messages.