### PR TITLE
Add missing namespace to container config

### DIFF
--- a/components/schemas/containers/config/ContainerRuntime.yml
+++ b/components/schemas/containers/config/ContainerRuntime.yml
@@ -29,6 +29,7 @@ properties:
         - network
         - mount
         - user
+        - cgroup
     description: Namespaces the given container will have access to.
   environment_vars:
     type: object


### PR DESCRIPTION
Adds the `cgroup` namespace to the potential values in the container config, where it was previously missing.