### PR TITLE
Remove min instances autoscale feat

### DIFF
--- a/components/schemas/containers/config/ContainerScale.yml
+++ b/components/schemas/containers/config/ContainerScale.yml
@@ -14,15 +14,11 @@ properties:
     type: object
     description: Describes how many instances should be running
     required:
-      - min
       - delta
       - max
       - max_server
       - min_ttl
     properties:
-      min:
-        type: integer
-        description: Minimum additional instances the auto-scaler will run at any time
       delta:
         type: integer
         description: Number of additional instances the auto-scaler will add/subtract per scaling event

--- a/components/schemas/stacks/spec/StackContainerConfigScaling.yml
+++ b/components/schemas/stacks/spec/StackContainerConfigScaling.yml
@@ -14,15 +14,11 @@ properties:
     type: object
     description: Describes how many instances should be running
     required:
-      - min
       - delta
       - max
       - max_server
       - min_ttl
     properties:
-      min:
-        type: integer
-        description: Minimum additional instances the auto-scaler will run at any time
       delta:
         type: integer
         description: Number of additional instances the auto-scaler will add/subtract per scaling event


### PR DESCRIPTION
Removing the min instances field in autoscale. Cycle will  always hold on to the baseline of instances now.