### PR TITLE
Remove deprecated job_id from task descriptor

### DIFF
--- a/components/schemas/jobs/TaskDescriptor.yml
+++ b/components/schemas/jobs/TaskDescriptor.yml
@@ -8,9 +8,6 @@ properties:
   action:
     type: string
     description: The action that was taken.
-  job_id:
-    type: string
-    description: The ID of the job associated with this task.
   job:
     type: object
     description: Contains some basic information about the job associated with this task.


### PR DESCRIPTION
Removes the deprecated `job_id` field from task descriptor responses.