### PR TITLE
Update auto-scale group scale-down section

### DIFF
--- a/components/schemas/infrastructure/auto-scale/groups/AutoScaleGroupScale.yml
+++ b/components/schemas/infrastructure/auto-scale/groups/AutoScaleGroupScale.yml
@@ -5,8 +5,12 @@ properties:
     title: AutoScaleGroupScaleDown
     type: object
     properties:
-      minimum:
-        type: integer
+      min_ttl:
+        description: "The minimum TTL for the server once deployed through an autoscale event."
+        $ref: ../../../Duration.yml
+      inactivity_period:
+        description: "The amount of time between last instance deployed and when the server can begin to get deleted."
+        $ref: ../../../Duration.yml
       method:
         type: string
         enum:


### PR DESCRIPTION
Removes the `min` field from auto-scale groups scale down options, while adding `min_ttl` and `inactivity_period`. Allows setting the minimum amount of time an ephemeral server must live before automatically being removed.