### PR TITLE
Upgrade to OpenAPI 3.1.0

### DIFF
--- a/components/schemas/ByteSize.yml
+++ b/components/schemas/ByteSize.yml
@@ -1,0 +1,7 @@
+title: ByteSize
+type: string
+description: A string signifying a size in bytes, kilobytes, megabytes, etc.
+examples:
+  - 1G
+  - 5M
+  - 2K

--- a/components/schemas/DateTime.yml
+++ b/components/schemas/DateTime.yml
@@ -2,4 +2,5 @@
 title: DateTime
 type: string
 format: date-time
-example: '2021-01-30T08:30:00Z'
+examples:
+  - "2021-01-30T08:30:00Z"

--- a/components/schemas/Duration.yml
+++ b/components/schemas/Duration.yml
@@ -1,4 +1,7 @@
 title: Duration
 type: string
 description: A string signifying a duration of time. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h", "d", "w", "y".
-example: 72h45m2s
+examples:
+  - 72h45m2s
+  - 3s
+  - 5m2s

--- a/components/schemas/ID.yml
+++ b/components/schemas/ID.yml
@@ -2,4 +2,5 @@
 title: ID
 type: string
 description: A 24 character hex string used to identify a unique resource.
-example: 651586fca6078e98982dbd90
+examples:
+  - 651586fca6078e98982dbd90

--- a/components/schemas/StateCountSummary.yml
+++ b/components/schemas/StateCountSummary.yml
@@ -3,9 +3,9 @@ title: ResourceCountSummary
 type: object
 description: A summary of resources by state
 required:
-- state
-- total
-- available
+  - state
+  - total
+  - available
 properties:
   state:
     title: CountsByState
@@ -19,13 +19,13 @@ properties:
   available:
     type: integer
     description: The total number of this resource available, less any deleted ones.
-example:
-  state:
-    new: 0
-    starting: 0
-    running: 5
-    stopping: 0
-    deleting: 0
-    deleted: 0
-  total: 5
-  available: 5
+examples:
+  - state:
+      new: 0
+      starting: 0
+      running: 5
+      stopping: 0
+      deleting: 0
+      deleted: 0
+    total: 5
+    available: 5

--- a/components/schemas/accounts/Account.yml
+++ b/components/schemas/accounts/Account.yml
@@ -42,8 +42,9 @@ properties:
         description: The date the email was added to the account
         "$ref": "../DateTime.yml"
   two_factor_auth:
-    type: object
-    nullable: true
+    type:
+      - "object"
+      - "null"
     description: Two factor auth verification information.
     required:
       - verified

--- a/components/schemas/billing/BillingBuilds.yml
+++ b/components/schemas/billing/BillingBuilds.yml
@@ -16,6 +16,7 @@ properties:
     type: number
     description: The amount of RAM availiable for builds
   max_daily_builds:
-    type: number
-    nullable: true
+    type:
+      - "number"
+      - "null"
     description: The maximum number of builds processed per day

--- a/components/schemas/billing/BillingOrder.yml
+++ b/components/schemas/billing/BillingOrder.yml
@@ -20,8 +20,9 @@ properties:
   creator:
     "$ref": "../creators/CreatorScope.yml"
   promo_code_id:
-    type: string
-    nullable: true
+    type:
+      - "string"
+      - "null"
     description: An ID associated with a promo code used with the order.
   term:
     "$ref": "./Term.yml"

--- a/components/schemas/billing/PromoCode.yml
+++ b/components/schemas/billing/PromoCode.yml
@@ -11,8 +11,9 @@ properties:
     type: string
     description: The promo "code".
   credit:
-    type: object
-    nullable: true
+    type:
+      - "object"
+      - "null"
     description: The amount of credit the promo code offers.
     additionalProperties:
       type: object

--- a/components/schemas/billing/SupportPlanFeatures.yml
+++ b/components/schemas/billing/SupportPlanFeatures.yml
@@ -13,6 +13,7 @@ properties:
     type: boolean
     description: A boolean where true represents the contract has an uptime SLA agreement.
   guaranteed_response_time:
-    nullable: true
-    type: string
+    type:
+      - "string"
+      - "null"
     description: The time in which this support contract guarantees response time.

--- a/components/schemas/billing/Term.yml
+++ b/components/schemas/billing/Term.yml
@@ -1,23 +1,23 @@
-title: BillingTerm 
-type: object 
-description: Information about a billing term. 
-required: 
-  - start 
-  - end 
-  - renew 
-properties: 
-  start: 
-    description: A timestamp describing the start of a billing term. 
-    "$ref": "../DateTime.yml" 
-  end: 
-    description: A timestamp describing the end of a billing term. 
-    "$ref": "../DateTime.yml" 
-  renew: 
-    type: string 
-    description: The term renewal period. 
-    enum: 
-      - once 
-      - monthly 
-      - yearly 
-    nullable: true
-    
+title: BillingTerm
+type: object
+description: Information about a billing term.
+required:
+  - start
+  - end
+  - renew
+properties:
+  start:
+    description: A timestamp describing the start of a billing term.
+    "$ref": "../DateTime.yml"
+  end:
+    description: A timestamp describing the end of a billing term.
+    "$ref": "../DateTime.yml"
+  renew:
+    type:
+      - "string"
+      - "null"
+    description: The term renewal period.
+    enum:
+      - once
+      - monthly
+      - yearly

--- a/components/schemas/billing/credits/Credit.yml
+++ b/components/schemas/billing/credits/Credit.yml
@@ -30,8 +30,9 @@ properties:
     type: integer
     description: The amount of the credit that remains after being applied to invoices.
   expires:
-    nullable: true
-    type: object
+    type:
+      - "object"
+      - "null"
     description: Information on when the billing credit expires.
     properties:
       date:

--- a/components/schemas/billing/orders/Order.yml
+++ b/components/schemas/billing/orders/Order.yml
@@ -18,8 +18,9 @@ properties:
   creator:
     "$ref": "../../common/UserScope.yml"
   promo_code_id:
-    type: string
-    nullable: true
+    type:
+      - "string"
+      - "null"
   term:
     "$ref": "../Term.yml"
   approved:

--- a/components/schemas/billing/plans/TierPlan.yml
+++ b/components/schemas/billing/plans/TierPlan.yml
@@ -37,11 +37,13 @@ properties:
   members:
     "$ref": "../BillingMembers.yml"
   max_nodes:
-    type: number
-    nullable: true
+    type:
+      - "number"
+      - "null"
   max_members:
-    type: number
-    nullable: true
+    type:
+      - "number"
+      - "null"
   advanced_features:
     type: object
     required:
@@ -59,8 +61,9 @@ properties:
       autoscale:
         type: boolean
   max_daily_api_requests:
-    type: number
-    nullable: true
+    type:
+      - "number"
+      - "null"
   ram:
     "$ref": "../BillingRam.yml"
   image_storage:

--- a/components/schemas/containers/Container.yml
+++ b/components/schemas/containers/Container.yml
@@ -45,16 +45,18 @@ properties:
     items:
       $ref: ./summaries/VolumeSummary.yml
   annotations:
-    type: object
+    type:
+      - "object"
+      - "null"
     description: Custom meta data for a given container
-    nullable: true
     additionalProperties: {}
   role:
-    type: string
+    type:
+      - "string"
+      - "null"
     description: The role of a given container if it has one.
     enum:
       - orchestrator
-    nullable: true
   stateful:
     type: boolean
     description: A boolean where true signifies the container is stateful.

--- a/components/schemas/containers/ServersList.yml
+++ b/components/schemas/containers/ServersList.yml
@@ -1,20 +1,20 @@
-title: ServerInstances 
-type: object 
-description: Information about the instances on a server. 
-required: 
-  - id 
-  - instances 
-  - hostname 
-properties: 
-  id: 
-    "$ref": "../ID.yml" 
-  instances: 
+title: ServerInstances
+type: object
+description: Information about the instances on a server.
+required:
+  - id
+  - instances
+  - hostname
+properties:
+  id:
+    "$ref": "../ID.yml"
+  instances:
     type: object
     description: A summary of resources by state
     required:
-    - state
-    - total
-    - available
+      - state
+      - total
+      - available
     properties:
       state:
         title: CountsByState
@@ -28,20 +28,19 @@ properties:
       available:
         type: integer
         description: The total number of this resource available, less any deleted ones.
-    example:
-      state:
-        new: 0
-        starting: 0
-        reimaging: 1
-        migrating: 1
-        running: 5
-        stopping: 0
-        failed: 0
-        deleting: 0
-        deleted: 0
-      total: 7
-      available: 5
-  hostname: 
-    type: string 
-    description: The server hostname. 
-
+    examples:
+      - state:
+          new: 0
+          starting: 0
+          reimaging: 1
+          migrating: 1
+          running: 5
+          stopping: 0
+          failed: 0
+          deleting: 0
+          deleted: 0
+        total: 7
+        available: 5
+  hostname:
+    type: string
+    description: The server hostname.

--- a/components/schemas/containers/backups/Logs.yml
+++ b/components/schemas/containers/backups/Logs.yml
@@ -34,8 +34,9 @@ properties:
     type: string
     description: The log.
   error:
-    type: object
-    nullable: true
+    type:
+      - "object"
+      - "null"
     required:
       - message
     properties:

--- a/components/schemas/containers/config/ContainerDeploy.yml
+++ b/components/schemas/containers/config/ContainerDeploy.yml
@@ -14,12 +14,14 @@ properties:
     type: object
     properties:
       options:
-        type: object
-        nullable: true
+        type:
+          - "object"
+          - "null"
         properties:
           use_base_hostname:
-            type: boolean
-            nullable: true
+            type:
+              - "boolean"
+              - "null"
   constraints:
     type: object
     description: Settings that give more granular control over deployment targets and conditions.

--- a/components/schemas/containers/config/ContainerIntegrations.yml
+++ b/components/schemas/containers/config/ContainerIntegrations.yml
@@ -86,18 +86,18 @@ properties:
             type: string
             description: The command to run for the backup.
           timeout:
-            type: string
-            nullable: true
             description: How long the backup will attempt to run before timing out.
-            allOf:
+            anyOf:
+              - type: "null"
               - $ref: ../../Duration.yml
           cron_string:
             type: string
             description: A cron string that configures how often the backup will run.
       restore:
-        type: object
+        type:
+          - "object"
+          - "null"
         description: Configuration settings for restoring from a backup.
-        nullable: true
         required:
           - command
         properties:
@@ -105,15 +105,13 @@ properties:
             type: string
             description: The command to run for restoring from a backup.
           timeout:
-            type: string
-            nullable: true
             description: The time in seconds for the restore to attempt to complete before timing out.
-            allOf:
+            anyOf:
+              - type: "null"
               - $ref: ../../Duration.yml
       retention:
-        type: string
-        nullable: true
         description: How long the platform will keep backups. Default is 1 year.
-        allOf:
+        anyOf:
+          - type: "null"
           - $ref: ../../Duration.yml
         default: "365d"

--- a/components/schemas/containers/config/ContainerResources.yml
+++ b/components/schemas/containers/config/ContainerResources.yml
@@ -29,9 +29,8 @@ properties:
     description: Configuration settings for limits and reserves of RAM resources for the given container.
     properties:
       limit:
-        type: string
         description: The limit (maximum) amount of RAM each instance of the given container can use.
-        example: "1G, 2M"
+        $ref: ../../ByteSize.yml
       reserve:
         type: string
         description: The reserve (allocation) of RAM given to each instance of the container.

--- a/components/schemas/containers/config/ContainerRuntime.yml
+++ b/components/schemas/containers/config/ContainerRuntime.yml
@@ -104,8 +104,9 @@ properties:
           type: integer
           description: The soft limit for the rlimit.
   seccomp:
-    nullable: true
-    type: object
+    type:
+      - "object"
+      - "null"
     properties:
       disable:
         type: boolean

--- a/components/schemas/containers/config/ContainerVolume.yml
+++ b/components/schemas/containers/config/ContainerVolume.yml
@@ -15,9 +15,8 @@ properties:
       - max_size
     properties:
       max_size:
-        type: string
-        description: The maximum size the volume can grow to. A number followed by a size. `10G` would be 10 gigabytes.
-        example: "10G"
+        description: The maximum size the volume can grow to.
+        $ref: ../../ByteSize.yml
       storage_pool:
         type: boolean
         description: A boolean where true signifies using the largest drive over 2TB for the target server.
@@ -42,8 +41,9 @@ properties:
         type: string
         description: Call out to a webhook to authenticate usernames/passwords if an organization manages their own accounts
       password:
-        type: object
-        nullable: true
+        type:
+          - "object"
+          - "null"
         description: Password configuration settings for the remote access of the container volume.
         required:
           - algorithm

--- a/components/schemas/containers/config/scale/ScaleThresholdMetricNetworkThroughput.yml
+++ b/components/schemas/containers/config/scale/ScaleThresholdMetricNetworkThroughput.yml
@@ -18,6 +18,5 @@ properties:
       private:
         type: boolean
       bandwidth:
-        type: string
+        $ref: ../../../ByteSize.yml
         description: The limit (maximum) amount of throughput each instance of the given container can use before triggering a scaling event.
-        example: "1G, 2M"

--- a/components/schemas/containers/config/scale/ScaleThresholdMetricRam.yml
+++ b/components/schemas/containers/config/scale/ScaleThresholdMetricRam.yml
@@ -15,6 +15,5 @@ properties:
       - used
     properties:
       used:
-        type: string
+        $ref: ../../../ByteSize.yml
         description: The limit (maximum) amount of RAM each instance of the given container can use before triggering a scaling event.
-        example: "1G, 2M"

--- a/components/schemas/containers/instances/Instance.yml
+++ b/components/schemas/containers/instances/Instance.yml
@@ -48,11 +48,13 @@ properties:
       subnet:
         type: string
       ipv6:
-        nullable: true
-        $ref: ../../environments/IPNet.yml
+        anyOf:
+          - type: "null"
+          - $ref: ../../environments/IPNet.yml
       legacy:
-        nullable: true
-        type: object
+        type:
+          - "object"
+          - "null"
         required:
           - host
           - subnet
@@ -63,17 +65,19 @@ properties:
           subnet:
             type: integer
           ipv4:
-            nullable: true
-            $ref: ../../environments/IPNet.yml
+            anyOf:
+              - type: "null"
+              - $ref: ../../environments/IPNet.yml
       mac_addr:
         type: string
       vxlan_tag:
         type: integer
 
   stateful:
-    type: object
+    type:
+      - "object"
+      - "null"
     description: Additional information about the instance relating to its setting as being stateful.
-    nullable: true
     required:
       - id
       - base_hostname
@@ -102,9 +106,10 @@ properties:
     type: string
     description: The hostname of the instance.
   migration:
-    type: object
+    type:
+      - "object"
+      - "null"
     description: If this instance is scheduled to be migrated or has been migrated in the past, there will be information populating this field with the server that the instance came from or the server that the instance was moved to and the instance ID.
-    nullable: true
     required:
       - key
       - copy_volumes
@@ -129,9 +134,10 @@ properties:
     description: If the instance was purged, the timestamp of when that happened.
     $ref: ../../DateTime.yml
   service:
-    type: string
+    type:
+      - "string"
+      - "null"
     description: If the instance is an instance of a service container that will be denoted here.
-    nullable: true
     enum:
       - discovery
       - vpn
@@ -139,9 +145,8 @@ properties:
   state:
     $ref: InstanceState.yml
   autoscale:
-    type: object
-    nullable: true
-    allOf:
+    anyOf:
+      - type: "null"
       - $ref: InstanceAutoScale.yml
   events:
     title: InstanceEvents

--- a/components/schemas/containers/instances/InstanceState.yml
+++ b/components/schemas/containers/instances/InstanceState.yml
@@ -19,16 +19,18 @@ allOf:
           - deleting
           - deleted
       health:
-        type: object
-        nullable: true
+        type:
+          - "object"
+          - "null"
         description: information about the health of the instance.
         required:
           - healthy
           - updated
         properties:
           healthy:
-            type: boolean
-            nullable: true
+            type:
+              - "boolean"
+              - "null"
             description: |
               Describes the healthiness of the instance. Health checks can be configured at the container level. 
               - `true`: The instance is considered healthy.

--- a/components/schemas/containers/summaries/ContainerEnvironmentSummary.yml
+++ b/components/schemas/containers/summaries/ContainerEnvironmentSummary.yml
@@ -1,8 +1,9 @@
 ---
 title: ContainerEnvironmentSummary
 description: A summary of supplemental environment and network information specific to a container.
-type: object
-nullable: true
+type:
+  - "object"
+  - "null"
 required:
   - id
   - cluster

--- a/components/schemas/containers/summaries/ContainerImageSummary.yml
+++ b/components/schemas/containers/summaries/ContainerImageSummary.yml
@@ -6,13 +6,14 @@ required:
   - id
   - service
 properties:
-  id: 
+  id:
     $ref: "../../ID.yml"
   service:
-    type: string
-    nullable: true
+    type:
+      - "string"
+      - "null"
     description: If this image is a service container this will say either `discovery` | `loadbalancer` | `vpn`.
-    enum: 
+    enum:
       - discovery
       - loadbalancer
       - vpn

--- a/components/schemas/containers/summaries/ImageSummary.yml
+++ b/components/schemas/containers/summaries/ImageSummary.yml
@@ -7,22 +7,23 @@ required:
   - extension
 properties:
   id:
-    type: string
-    nullable: true
     allOf:
+      - type: "null"
       - $ref: "../../ID.yml"
   extension:
-    type: object
+    type:
+      - "object"
+      - "null"
     description: An image that is packaged with Cycle directly, such as the global load balancer.
-    nullable: true
     required:
       - identifier
     properties:
       identifier:
         $ref: ../../Identifier.yml
   service:
-    type: string
-    nullable: true
+    type:
+      - "string"
+      - "null"
     description: If a service container, the identifier specifying which service it is.
     enum:
       - "loadbalancer"

--- a/components/schemas/creators/ApiKeyCreator.yml
+++ b/components/schemas/creators/ApiKeyCreator.yml
@@ -3,15 +3,15 @@ title: ApiKeyCreator
 description: An extended resource that has information on a Cycle hub API key
 type: object
 required:
- - id
- - name
- - creator
- - hub_id
- - permissions
- - capabilities
- - ips
- - state
- - events
+  - id
+  - name
+  - creator
+  - hub_id
+  - permissions
+  - capabilities
+  - ips
+  - state
+  - events
 properties:
   id:
     $ref: "../ID.yml"
@@ -36,24 +36,25 @@ properties:
         type: boolean
       specific:
         type: array
-        items: 
+        items:
           type: string
   ips:
-    type: array
-    nullable: true
-    items: 
+    type:
+      - "array"
+      - "null"
+    items:
       type: string
-  state: 
+  state:
     allOf:
-    - required:
-      - current
-      properties:
-        current:
-          type: string
-          enum:
-          - live
-          - deleting
-          - deleted
-    - "$ref": "../State.yml"
+      - required:
+          - current
+        properties:
+          current:
+            type: string
+            enum:
+              - live
+              - deleting
+              - deleted
+      - "$ref": "../State.yml"
   events:
     $ref: "../Events.yml"

--- a/components/schemas/dns/records/Certificate.yml
+++ b/components/schemas/dns/records/Certificate.yml
@@ -1,11 +1,12 @@
 title: DNSRecordCertificate
-type: object
+type:
+  - "object"
+  - "null"
 description: A TLS record certificate
 required:
   - id
   - generated
   - wildcard_child
-nullable: true
 properties:
   id:
     "$ref": "../../ID.yml"

--- a/components/schemas/dns/records/Record.yml
+++ b/components/schemas/dns/records/Record.yml
@@ -31,11 +31,12 @@ properties:
   type:
     $ref: RecordTypes.yml
   features:
-    type: object
+    type:
+      - "object"
+      - "null"
     description: TLS features for the record.
     required:
       - certificate
-    nullable: true
     properties:
       certificate:
         $ref: Certificate.yml

--- a/components/schemas/environments/IPNet.yml
+++ b/components/schemas/environments/IPNet.yml
@@ -2,14 +2,16 @@
 title: IPNet
 type: object
 required:
-- ip
-- cidr
+  - ip
+  - cidr
 properties:
   ip:
     type: string
     description: The IP address.
-    example: fd00::21:0:0:0
+    examples:
+      - fd00::21:0:0:0
   cidr:
     type: string
     description: The CIDR notation, describing the range of IP addresses.
-    example: fd00::21:0:0:0/96
+    examples:
+      - fd00::21:0:0:0/96

--- a/components/schemas/environments/LegacyNetwork.yml
+++ b/components/schemas/environments/LegacyNetwork.yml
@@ -1,7 +1,8 @@
 ---
 title: LegacyNetwork
-type: object
-nullable: true
+type:
+  - "object"
+  - "null"
 description: Legacy network information for an environment.
 required:
   - subnet

--- a/components/schemas/environments/PrivateNetwork.yml
+++ b/components/schemas/environments/PrivateNetwork.yml
@@ -1,12 +1,13 @@
 ---
 title: PrivateNetwork
-type: object
-nullable: true
+type:
+  - "object"
+  - "null"
 required:
-- vxlan_tag
-- subnet
-- ipv6
-- legacy
+  - vxlan_tag
+  - subnet
+  - ipv6
+  - legacy
 properties:
   vxlan_tag:
     type: integer
@@ -16,8 +17,7 @@ properties:
     description: The subnet ID.
   ipv6:
     allOf:
-    - description: The IPv6 interface.
-    - "$ref": "./IPNet.yml"
+      - description: The IPv6 interface.
+      - "$ref": "./IPNet.yml"
   legacy:
     $ref: "./LegacyNetwork.yml"
-

--- a/components/schemas/environments/services/DiscoveryEnvironmentService.yml
+++ b/components/schemas/environments/services/DiscoveryEnvironmentService.yml
@@ -1,7 +1,8 @@
 ---
 title: DiscoveryEnvironmentService
-type: object
-nullable: true
+type:
+  - "object"
+  - "null"
 description: Information about the environments discovery service(s).
 required:
   - enable
@@ -21,6 +22,7 @@ properties:
       A boolean representing if this service container is set to high availability
       mode or not.
   config:
-    nullable: true
-    type: object
+    type:
+      - "object"
+      - "null"
     description: The config object for the discovery service.

--- a/components/schemas/environments/services/LoadBalancerEnvironmentService.yml
+++ b/components/schemas/environments/services/LoadBalancerEnvironmentService.yml
@@ -1,7 +1,8 @@
 ---
 title: LoadBalancerEnvironmentService
-type: object
-nullable: true
+type:
+  - "object"
+  - "null"
 description: Information about the environments loadbalancer service(s).
 required:
   - enable
@@ -13,8 +14,9 @@ properties:
     type: boolean
     description: Whether or not the loadbalancer service is enabled.
   container_id:
-    type: string
-    nullable: true
+    type:
+      - "string"
+      - "null"
     description: The ID of the loadbalancer service container
   high_availability:
     type: boolean

--- a/components/schemas/environments/services/VpnEnvironmentService.yml
+++ b/components/schemas/environments/services/VpnEnvironmentService.yml
@@ -1,13 +1,14 @@
 ---
 title: VpnEnvironmentService
-type: object
-nullable: true
+type:
+  - "object"
+  - "null"
 description: Information about the environments vpn service(s).
 required:
-- enable
-- container_id
-- high_availability
-- config
+  - enable
+  - container_id
+  - high_availability
+  - config
 properties:
   enable:
     type: boolean
@@ -17,15 +18,17 @@ properties:
     description: The ID of the VPN service container
   high_availability:
     type: boolean
-    description: A boolean representing if this service container is set to high availability
+    description:
+      A boolean representing if this service container is set to high availability
       mode or not.
   config:
-    type: object
-    nullable: true
+    type:
+      - "object"
+      - "null"
     description: The config object for the VPN service.
     required:
-    - allow_internet
-    - auth
+      - allow_internet
+      - auth
     properties:
       allow_internet:
         type: boolean
@@ -34,20 +37,24 @@ properties:
         type: object
         description: Auth configuration for the VPN.
         required:
-        - webhook
-        - cycle_accounts
+          - webhook
+          - cycle_accounts
         properties:
           webhook:
-            type: string
-            nullable: true
-            description: A webhook endpoint to hit. Will be passed the login credentials
+            type:
+              - "string"
+              - "null"
+            description:
+              A webhook endpoint to hit. Will be passed the login credentials
               provided to the user, and should return a 200 status if the login is
               permitted.
           cycle_accounts:
             type: boolean
-            description: If true, allows any Cycle account with access to the environment
+            description:
+              If true, allows any Cycle account with access to the environment
               to log in to the VPN using their Cycle email and password.
           vpn_accounts:
             type: boolean
-            description: If true, allows the custom VPN accounts to log in to the
+            description:
+              If true, allows the custom VPN accounts to log in to the
               VPN.

--- a/components/schemas/environments/services/lb/LoadBalancerConfig.yml
+++ b/components/schemas/environments/services/lb/LoadBalancerConfig.yml
@@ -1,7 +1,8 @@
 title: LoadBalancerConfig
-type: object
+type:
+  - "object"
+  - "null"
 description: The config object for the loadbalancer service.
-nullable: true
 discriminator:
   propertyName: type
   mapping:

--- a/components/schemas/environments/services/lb/telemetry/LoadBalancerLatestTelemetry.yml
+++ b/components/schemas/environments/services/lb/telemetry/LoadBalancerLatestTelemetry.yml
@@ -49,9 +49,8 @@ items:
           controller:
             $ref: ../../../../Identifier.yml
           latest:
-            type: object
-            nullable: true
             allOf:
+              - type: "null"
               - $ref: LoadBalancerTelemetrySnapshot.yml
           snapshots:
             type: array

--- a/components/schemas/environments/services/lb/telemetry/LoadBalancerTelemetryReport.yml
+++ b/components/schemas/environments/services/lb/telemetry/LoadBalancerTelemetryReport.yml
@@ -11,8 +11,9 @@ properties:
   range:
     $ref: ../../../../Range.yml
   snapshots:
-    type: array
-    nullable: true
+    type:
+      - "array"
+      - "null"
     items:
       type: object
       title: LoadBalancerTelemetryReportMergedSnapshot

--- a/components/schemas/environments/services/lb/telemetry/LoadBalancerTelemetryRouterMetrics.yml
+++ b/components/schemas/environments/services/lb/telemetry/LoadBalancerTelemetryRouterMetrics.yml
@@ -12,8 +12,9 @@ properties:
         - requests
       properties:
         connections:
-          nullable: true
-          type: object
+          type:
+            - "object"
+            - "null"
           required:
             - success
             - unavailable
@@ -27,8 +28,9 @@ properties:
               additionalProperties:
                 type: integer
         requests:
-          nullable: true
-          type: object
+          type:
+            - "object"
+            - "null"
           required:
             - total
           properties:

--- a/components/schemas/environments/services/lb/telemetry/LoadBalancerTelemetryUrlMetrics.yml
+++ b/components/schemas/environments/services/lb/telemetry/LoadBalancerTelemetryUrlMetrics.yml
@@ -11,8 +11,9 @@ properties:
         - requests
       properties:
         requests:
-          nullable: true
-          type: object
+          type:
+            - "object"
+            - "null"
           required:
             - total
           properties:

--- a/components/schemas/environments/services/vpn/taskActions/VpnReconfigureTask.yml
+++ b/components/schemas/environments/services/vpn/taskActions/VpnReconfigureTask.yml
@@ -17,8 +17,9 @@ properties:
         type: boolean
         description: A boolean where true means the VPN service is enabled.
       config:
-        type: object
-        nullable: true
+        type:
+          - "object"
+          - "null"
         description: The config object for the VPN service, in this case without the required fields normally found in a VPN config object.
         properties:
           allow_internet:
@@ -32,8 +33,9 @@ properties:
               - cycle_accounts
             properties:
               webhook:
-                type: string
-                nullable: true
+                type:
+                  - "string"
+                  - "null"
                 description:
                   A webhook endpoint to hit. Will be passed the login credentials
                   provided to the user, and should return a 200 status if the login is

--- a/components/schemas/environments/summaries/EnvironmentSummary.yml
+++ b/components/schemas/environments/summaries/EnvironmentSummary.yml
@@ -22,14 +22,17 @@ properties:
       - vpn
     properties:
       loadbalancer:
-        nullable: true
-        $ref: "./EnvironmentServiceContainerSummary.yml"
+        anyOf:
+          - type: "null"
+          - $ref: "./EnvironmentServiceContainerSummary.yml"
       discovery:
-        nullable: true
-        $ref: "./EnvironmentServiceContainerSummary.yml"
+        anyOf:
+          - type: "null"
+          - $ref: "./EnvironmentServiceContainerSummary.yml"
       vpn:
-        nullable: true
-        $ref: "./EnvironmentServiceContainerSummary.yml"
+        anyOf:
+          - type: "null"
+          - $ref: "./EnvironmentServiceContainerSummary.yml"
   stats:
     title: EnvironmentSummaryStats
     type: object

--- a/components/schemas/errors/ErrorEnvelope.yml
+++ b/components/schemas/errors/ErrorEnvelope.yml
@@ -9,5 +9,4 @@ properties:
     $ref: Error.yml
   data:
     description: Data will always be `null` here.
-    type: object
-    nullable: true
+    type: "null"

--- a/components/schemas/hubs/ApiKey.yml
+++ b/components/schemas/hubs/ApiKey.yml
@@ -66,11 +66,12 @@ properties:
         items:
           "$ref": "../common/Capability.yml"
   ips:
-    type: array
+    type:
+      - "array"
+      - "null"
     description: An array of IP's this API key can make calls from.
     items:
       type: string
-    nullable: true
   state:
     "$ref": "./ApiKeyState.yml"
   events:

--- a/components/schemas/hubs/Hub.yml
+++ b/components/schemas/hubs/Hub.yml
@@ -65,9 +65,8 @@ properties:
   webhooks:
     $ref: HubWebhooks.yml
   billing:
-    allOf:
-      - type: object
-        nullable: true
+    anyOf:
+      - type: "null"
       - $ref: "./HubBillingProfile.yml"
   meta:
     "$ref": "./HubMeta.yml"

--- a/components/schemas/hubs/HubBillingProfile.yml
+++ b/components/schemas/hubs/HubBillingProfile.yml
@@ -26,16 +26,19 @@ properties:
       - support_id
     properties:
       tier_id:
-        type: string
-        nullable: true
+        type:
+          - "string"
+          - "null"
         description: An ID referencing the pricing tier applied to this hub.
       support_id:
-        type: string
-        nullable: true
+        type:
+          - "string"
+          - "null"
         description: An ID referencing the support plan applied to this hub.
   emails:
-    type: array
-    nullable: true
+    type:
+      - "array"
+      - "null"
     items:
       type: string
     description: An array of email addresses to whom the billing invoices will be sent to. If left empty, they will be sent to the owner of this hub.

--- a/components/schemas/hubs/HubIntegrations.yml
+++ b/components/schemas/hubs/HubIntegrations.yml
@@ -1,38 +1,37 @@
-title: HubIntegrations 
-description: Integration information for a given hub. 
-type: object 
-required: 
-  - letsencrypt 
+title: HubIntegrations
+description: Integration information for a given hub.
+type: object
+required:
+  - letsencrypt
   - backblaze_b2
-properties: 
-  letsencrypt: 
-    type: object 
-    description: A hub integration with Lets Encrypt service. 
-    required: 
-      - email 
-    nullable: true
-    properties: 
-      email: 
-        type: string 
-        description: An email address to assocaite with Lets Encrypt certificates generated for DNS records on this hub. 
-  backblaze_b2: 
-    type: object 
-    description: Information about the Backblaze account and bucket assocaited with the given hub. 
-    required: 
+properties:
+  letsencrypt:
+    type:
+      - "object"
+      - "null"
+    description: A hub integration with Lets Encrypt service.
+    required:
+      - email
+    properties:
+      email:
+        type: string
+        description: An email address to assocaite with Lets Encrypt certificates generated for DNS records on this hub.
+  backblaze_b2:
+    type:
+      - "object"
+      - "null"
+    description: Information about the Backblaze account and bucket assocaited with the given hub.
+    required:
       - bucket
-      - key_id 
-      - key 
-    nullable: true
-    properties: 
-      bucket: 
-        type: string 
-        description: The bucket name. 
-      key_id: 
-        type: string 
-        description: The `key_id` from Backblaze for a given key ( the one used for this integration ). 
-      key: 
-        type: string 
-        description: The key associated with the bucket. 
-  
-
-    
+      - key_id
+      - key
+    properties:
+      bucket:
+        type: string
+        description: The bucket name.
+      key_id:
+        type: string
+        description: The `key_id` from Backblaze for a given key ( the one used for this integration ).
+      key:
+        type: string
+        description: The key associated with the bucket.

--- a/components/schemas/hubs/HubMembership.yml
+++ b/components/schemas/hubs/HubMembership.yml
@@ -116,11 +116,13 @@ properties:
                   - offline
                 properties:
                   new:
-                    nullable: true
-                    type: boolean
+                    type:
+                      - "boolean"
+                      - "null"
                   offline:
-                    nullable: true
-                    type: boolean
+                    type:
+                      - "boolean"
+                      - "null"
   state:
     "$ref": "./MembershipState.yml"
   invitation:

--- a/components/schemas/hubs/HubWebhooks.yml
+++ b/components/schemas/hubs/HubWebhooks.yml
@@ -6,10 +6,12 @@ required:
   - server_deleted
 properties:
   server_deployed:
-    nullable: true
-    type: string
+    type:
+      - "string"
+      - "null"
     description: A webhook that is called any time a server is deployed to this hub. The payload will be a `Server` object.
   server_deleted:
-    nullable: true
-    type: string
+    type:
+      - "string"
+      - "null"
     description: A webhook that is called any time a server in this hub is deleted. The payload will be a `Server` object.

--- a/components/schemas/hubs/activity/Activity.yml
+++ b/components/schemas/hubs/activity/Activity.yml
@@ -53,9 +53,8 @@ properties:
   context:
     $ref: Context.yml
   session:
-    type: object
-    nullable: true
     anyOf:
+      - type: "null"
       - $ref: Session.yml
   changes:
     type: array
@@ -67,9 +66,10 @@ properties:
     description: A record of additional annotations for the activity.
     additionalProperties: {}
   error:
-    type: object
+    type:
+      - "object"
+      - "null"
     description: An object describing a given activity error.
-    nullable: true
     required:
       - message
     properties:
@@ -77,9 +77,10 @@ properties:
         type: string
         description: The error message.
   component:
-    type: object
+    type:
+      - "object"
+      - "null"
     description: An object holding information about a component.
-    nullable: true
     required:
       - id
       - type

--- a/components/schemas/hubs/activity/Session.yml
+++ b/components/schemas/hubs/activity/Session.yml
@@ -14,8 +14,9 @@ properties:
     type: string
     description: The IP of the account associated with the session.
   token:
-    type: object
-    nullable: true
+    type:
+      - "object"
+      - "null"
     required:
       - application_id
       - application_capabilities_version
@@ -25,6 +26,7 @@ properties:
       application_capabilities_version:
         type: integer
   api_key:
-    type: string
+    type:
+      - "string"
+      - "null"
     description: The API key ID.
-    nullable: true

--- a/components/schemas/images/Image.yml
+++ b/components/schemas/images/Image.yml
@@ -31,8 +31,9 @@ properties:
       - description
     properties:
       description:
-        type: string
-        nullable: true
+        type:
+          - "string"
+          - "null"
         description: A description of the image.
   backend:
     type: object
@@ -62,8 +63,9 @@ properties:
       nvidia_gpu:
         type: boolean
   build:
-    type: object
-    nullable: true
+    type:
+      - "object"
+      - "null"
     description: Any additional build details for this image
     properties:
       args:
@@ -162,8 +164,9 @@ properties:
   creator:
     "$ref": "../creators/CreatorScope.yml"
   factory:
-    type: object
-    nullable: true
+    type:
+      - "object"
+      - "null"
     description: Identifies which factory the image was built on and when.
     required:
       - node_id

--- a/components/schemas/images/origins/auth/RegistryAuth.yml
+++ b/components/schemas/images/origins/auth/RegistryAuth.yml
@@ -1,6 +1,7 @@
 title: RegistryAuth
-type: object
-nullable: true
+type:
+  - "object"
+  - "null"
 description: Authentication details for a third party image registry/source.
 discriminator:
   propertyName: type

--- a/components/schemas/includes/CreatorInclude.yml
+++ b/components/schemas/includes/CreatorInclude.yml
@@ -12,28 +12,24 @@ properties:
   employees:
     type: object
     description: Included creators that are employees of Cycle, keyed by ID.
-    example:
     additionalProperties:
       # Set the whole public account schema for each key-value.
       $ref: "../creators/PublicAccount.yml"
   visitors:
     type: object
     description: Included creators that are not Cycle accounts, keyed by ID.
-    example:
     additionalProperties:
       # Set the whole public account schema for each key-value.
       $ref: "../creators/PublicAccount.yml"
   environments:
     type: object
     description: Included creators that are Cycle environments (usually automatically created resources), keyed by ID.
-    example:
     additionalProperties:
       # Set the whole public account schema for each key-value.
       $ref: "../environments/Environment.yml"
   api_keys:
     type: object
     description: Included creators that are Cycle API Keys, keyed by ID.
-    example:
     additionalProperties:
       # Set the whole public account schema for each key-value.
       $ref: "../creators/ApiKeyCreator.yml"

--- a/components/schemas/infrastructure/ips/Ip.yml
+++ b/components/schemas/infrastructure/ips/Ip.yml
@@ -23,9 +23,10 @@ properties:
       - ipv4
       - ipv6
   assignment:
-    type: object
+    type:
+      - "object"
+      - "null"
     description: Information about the assignment of this IP.
-    nullable: true
     required:
       - container_id
       - instance_id

--- a/components/schemas/infrastructure/providers/InfrastructureProviderLocation.yml
+++ b/components/schemas/infrastructure/providers/InfrastructureProviderLocation.yml
@@ -17,9 +17,8 @@ properties:
     type: string
     description: A name for the location.
   geographic:
-    allOf:
-      - type: object
-        nullable: true
+    anyOf:
+      - type: "null"
       - $ref: ./Geographic.yml
   provider:
     $ref: ./LocationProvider.yml

--- a/components/schemas/infrastructure/servers/Server.yml
+++ b/components/schemas/infrastructure/servers/Server.yml
@@ -47,8 +47,9 @@ properties:
   constraints:
     $ref: "./ServerConstraints.yml"
   autoscale:
-    nullable: true
-    type: object
+    type:
+      - "object"
+      - "null"
     required:
       - group_id
     properties:
@@ -58,9 +59,10 @@ properties:
     type: boolean
     description: Set to true when a server is created as part of an auto-scale event.
   evacuate:
-    nullable: true
+    type:
+      - "object"
+      - "null"
     description: Details about a server's evacuation status. When an evacuation is in progress, no new container instances will be permitted on the server.
-    type: object
     required:
       - started
     properties:

--- a/components/schemas/infrastructure/servers/taskActions/ReconfigureServer.yml
+++ b/components/schemas/infrastructure/servers/taskActions/ReconfigureServer.yml
@@ -1,25 +1,26 @@
 title: ReconfigureServerAction
-type: object 
-required: 
-- action 
-- contents 
-properties: 
-  action: 
-    type: string 
-    description: The action to take. 
-    enum: 
+type: object
+required:
+  - action
+  - contents
+properties:
+  action:
+    type: string
+    description: The action to take.
+    enum:
       - "reconfigure.features"
-  contents: 
-    type: object 
-    description: Supplemental information needed to perform the action. 
-    required: 
-      - sftp 
-      - base_volume_gb 
-    properties: 
-      sftp: 
-        type: boolean 
-        description: A boolean where true represents the desire for the server to accept incoming SFTP requests for container volumes. 
-      base_volume_gb: 
-        type: integer 
-        description: A number in GB for how big the base volume should be.  This cannot be lower than the currently set value for the server. 
-        nullable: true 
+  contents:
+    type: object
+    description: Supplemental information needed to perform the action.
+    required:
+      - sftp
+      - base_volume_gb
+    properties:
+      sftp:
+        type: boolean
+        description: A boolean where true represents the desire for the server to accept incoming SFTP requests for container volumes.
+      base_volume_gb:
+        type:
+          - "integer"
+          - "null"
+        description: A number in GB for how big the base volume should be.  This cannot be lower than the currently set value for the server.

--- a/components/schemas/infrastructure/specs/FeaturesSpec.yml
+++ b/components/schemas/infrastructure/specs/FeaturesSpec.yml
@@ -1,24 +1,24 @@
-title: FeaturesServerSpec 
+title: FeaturesServerSpec
 type: object
-required: 
-  - raid 
+required:
+  - raid
 description: The spec for server features.
 properties:
-  raid: 
-    type: string 
-    description: The type of raid supported, if any. 
-    nullable: true 
-  aws: 
-    type: object 
-    description: Features specific to AWS. 
-    required:   
-      - ena_support 
-      - ebs_optimized 
-    properties: 
-      ena_support: 
-        type: boolean 
-        description: A boolean where true indicates this is a machine that can support a much higher networking throughput. 
-      ebs_optimized: 
-        type: boolean 
-        description: A boolean where true indicates this is a machine that can support higher storage throughput. 
-  
+  raid:
+    type:
+      - "string"
+      - "null"
+    description: The type of raid supported, if any.
+  aws:
+    type: object
+    description: Features specific to AWS.
+    required:
+      - ena_support
+      - ebs_optimized
+    properties:
+      ena_support:
+        type: boolean
+        description: A boolean where true indicates this is a machine that can support a much higher networking throughput.
+      ebs_optimized:
+        type: boolean
+        description: A boolean where true indicates this is a machine that can support higher storage throughput.

--- a/components/schemas/jobs/JobTasks.yml
+++ b/components/schemas/jobs/JobTasks.yml
@@ -1,29 +1,29 @@
-title: JobTasks 
-description: Information about a job task. 
-required: 
-  - id 
-  - caption 
-  - header 
-  - action 
-  - events 
-  - steps 
-  - state 
-  - failable 
-  - input 
-  - output 
-  - error 
-properties: 
-  id: 
-    "$ref": "../ID.yml" 
-  caption: 
-    type: string 
-    description: A short description of the task. 
-  header: 
-    type: string 
-    description: The API function called. 
-  action: 
-    type: string 
-    description: The action being handled by the job. 
+title: JobTasks
+description: Information about a job task.
+required:
+  - id
+  - caption
+  - header
+  - action
+  - events
+  - steps
+  - state
+  - failable
+  - input
+  - output
+  - error
+properties:
+  id:
+    "$ref": "../ID.yml"
+  caption:
+    type: string
+    description: A short description of the task.
+  header:
+    type: string
+    description: The API function called.
+  action:
+    type: string
+    description: The action being handled by the job.
   events:
     title: JobEvents
     type: object
@@ -42,33 +42,34 @@ properties:
       started:
         description: The timestamp of when the job was started.
         "$ref": "../DateTime.yml"
-  steps: 
-    description: An array of job task steps. 
-    type: array 
-    items: 
-      "$ref": "./TaskStep.yml" 
-  state: 
-    "$ref": "./TaskState.yml" 
-  failable: 
-    type: boolean 
-    description:  A boolean where true indicates the job is failable. 
-  input: 
-    type: object 
-    description: Input information used for the job tasks. 
-    additionalProperties: 
-      type: string 
-  output: 
-    type: object 
-    description: Output informaiton used for the job tasks. 
+  steps:
+    description: An array of job task steps.
+    type: array
+    items:
+      "$ref": "./TaskStep.yml"
+  state:
+    "$ref": "./TaskState.yml"
+  failable:
+    type: boolean
+    description: A boolean where true indicates the job is failable.
+  input:
+    type: object
+    description: Input information used for the job tasks.
     additionalProperties:
-      type: string 
-  error: 
-    type: object 
-    description: An error object describing issues with the job. 
-    required: 
-      - message 
-    properties: 
-      message: 
-        type: string 
-        description: An error message 
-        nullable: true
+      type: string
+  output:
+    type: object
+    description: Output informaiton used for the job tasks.
+    additionalProperties:
+      type: string
+  error:
+    type: object
+    description: An error object describing issues with the job.
+    required:
+      - message
+    properties:
+      message:
+        type:
+          - "object"
+          - "null"
+        description: An error message

--- a/components/schemas/scoped-variables/ScopedVariable.yml
+++ b/components/schemas/scoped-variables/ScopedVariable.yml
@@ -27,8 +27,9 @@ properties:
     type: string
     description: An identifier, similar to a key in an environment variable.  Its used when envoking the scoped variable.
   secret:
-    nullable: true
-    type: object
+    type:
+      - "object"
+      - "null"
     description: An object with information about the encryption of the scoped variable.
     required:
       - encrypted

--- a/components/schemas/sdn/global-lbs/GlobalLoadBalancer.yml
+++ b/components/schemas/sdn/global-lbs/GlobalLoadBalancer.yml
@@ -30,8 +30,9 @@ properties:
   state:
     $ref: GlobalLoadBalancerState.yml
   environments:
-    type: array
-    nullable: true
+    type:
+      - "array"
+      - "null"
     description: An array where each item lists an environment ID and settings for the global load balancer to route traffic to them.
     items:
       title: GlobalLoadBalancerEnvironment

--- a/components/schemas/stacks/Stack.json
+++ b/components/schemas/stacks/Stack.json
@@ -1,0 +1,67 @@
+{
+  "title": "Stack",
+  "type": "object",
+  "description": "Stacks are a way to orchestrate multiple containers atomically and automatically.",
+  "required": [
+    "id",
+    "identifier",
+    "name",
+    "hub_id",
+    "creator",
+    "source",
+    "state",
+    "events"
+  ],
+  "properties": {
+    "id": {
+      "$ref": "../ID.yml"
+    },
+    "identifier": {
+      "$ref": "../Identifier.yml",
+      "description": "A human readable slugged identifier for this stack."
+    },
+    "name": {
+      "type": "string",
+      "description": "A user defined name for the stack resource."
+    },
+    "hub_id": {
+      "$ref": "../HubID.yml"
+    },
+    "creator": {
+      "$ref": "../common/UserScope.yml"
+    },
+    "source": {
+      "$ref": "./StackSource.yml"
+    },
+    "state": {
+      "$ref": "./StackState.yml"
+    },
+    "events": {
+      "title": "StackEvents",
+      "type": "object",
+      "description": "A collection of timestamps for each event in the Stacks lifetime.",
+      "required": ["created", "updated", "deleted", "last_build"],
+      "properties": {
+        "created": {
+          "description": "The timestamp of when the stack was created.",
+          "$ref": "../DateTime.yml"
+        },
+        "updated": {
+          "description": "The timestamp of when the stack was updated.",
+          "$ref": "../DateTime.yml"
+        },
+        "deleted": {
+          "description": "The timestamp of when the stack was deleted.",
+          "$ref": "../DateTime.yml"
+        },
+        "last_build": {
+          "description": "The timestamp for the last build of the stack.",
+          "$ref": "../DateTime.yml"
+        }
+      }
+    },
+    "meta": {
+      "$ref": "./StackMeta.yml"
+    }
+  }
+}

--- a/components/schemas/stacks/spec/StackContainerConfigDeploy.yml
+++ b/components/schemas/stacks/spec/StackContainerConfigDeploy.yml
@@ -20,12 +20,14 @@ properties:
       - options
     properties:
       options:
-        nullable: true
-        type: object
+        type:
+          - "object"
+          - "null"
         properties:
           use_base_hostname:
-            type: boolean
-            nullable: true
+            type:
+              - "boolean"
+              - "null"
   constraints:
     type: object
     properties:
@@ -57,10 +59,9 @@ properties:
     type: object
     properties:
       graceful_timeout:
-        type: string
-        nullable: true
         description: How long the platform will wait for a container to stop gracefully.
-        allOf:
+        anyOf:
+          - type: "null"
           - $ref: ../../Duration.yml
       signals:
         type: array
@@ -70,10 +71,9 @@ properties:
     type: object
     properties:
       delay:
-        nullable: true
-        type: string
         description: How long the platform will wait before sending the start signal to the given container.
-        allOf:
+        anyOf:
+          - type: "null"
           - $ref: ../../Duration.yml
   update:
     type: object
@@ -121,7 +121,8 @@ properties:
       command:
         type: string
         description: The command to run as your health check
-        example: /bin/sh healthcheck.sh
+        examples:
+          - /bin/sh healthcheck.sh
       retries:
         type: integer
         description: The number of times to retry the command before marking an instance unhealthy

--- a/components/schemas/stacks/spec/StackContainerConfigIntegrations.yml
+++ b/components/schemas/stacks/spec/StackContainerConfigIntegrations.yml
@@ -64,17 +64,18 @@ properties:
           command:
             type: string
           timeout:
-            type: string
-            nullable: true
             description: How long the backup will attempt to run before timing out.
-            allOf:
+            anyOf:
+              - type: "null"
               - $ref: ../../Duration.yml
           cron_string:
-            nullable: true
-            type: string
+            type:
+              - "string"
+              - "null"
       restore:
-        nullable: true
-        type: object
+        type:
+          - "object"
+          - "null"
         required:
           - command
           - timeout
@@ -82,15 +83,13 @@ properties:
           command:
             type: string
           timeout:
-            type: string
-            nullable: true
             description: The time in seconds for the restore to attempt to complete before timing out.
-            allOf:
+            anyOf:
+              - type: "null"
               - $ref: ../../Duration.yml
       retention:
-        type: string
-        nullable: true
         description: How long the platform will keep backups. Default is 1 year.
-        allOf:
+        anyOf:
+          - type: "null"
           - $ref: ../../Duration.yml
         default: "365d"

--- a/components/schemas/stacks/spec/StackContainerVolume.yml
+++ b/components/schemas/stacks/spec/StackContainerVolume.yml
@@ -40,8 +40,9 @@ properties:
             read_only:
               type: boolean
             password:
-              nullable: true
-              type: object
+              type:
+                - "object"
+                - "null"
               required:
                 - algorithm
                 - data

--- a/components/schemas/stacks/spec/StackSpecContainerImage.yml
+++ b/components/schemas/stacks/spec/StackSpecContainerImage.yml
@@ -5,8 +5,9 @@ required:
   - origin
 properties:
   name:
-    nullable: true
-    type: string
+    type:
+      - "string"
+      - "null"
   origin:
     $ref: "../../images/origins/ImageOrigin.yml"
   build:

--- a/components/schemas/stacks/spec/StackSpecTestContainer.yml
+++ b/components/schemas/stacks/spec/StackSpecTestContainer.yml
@@ -8,21 +8,19 @@ properties:
   name:
     type: string
   image:
-    type: object
-    nullable: true
-    allOf:
+    anyOf:
+      - type: "null"
       - $ref: StackSpecContainerImage.yml
   config:
-    type: object
-    nullable: true
+    type:
+      - "object"
+      - "null"
     properties:
       runtime:
-        nullable: true
-        type: object
-        allOf:
+        anyOf:
+          - type: "null"
           - $ref: StackContainerConfigRuntime.yml
       resources:
-        nullable: true
-        type: object
-        allOf:
+        anyOf:
+          - type: "null"
           - $ref: StackContainerConfigResources.yml

--- a/components/schemas/stacks/spec/scale/StackContainerScaleThresholdNetworkThroughput.yml
+++ b/components/schemas/stacks/spec/scale/StackContainerScaleThresholdNetworkThroughput.yml
@@ -18,6 +18,5 @@ properties:
       private:
         type: boolean
       bandwidth:
-        type: string
+        $ref: ../../../ByteSize.yml
         description: The limit (maximum) amount of throughput each instance of the given container can use before triggering a scaling event.
-        example: "1G, 2M"

--- a/components/schemas/stacks/spec/scale/StackContainerScaleThresholdRam.yml
+++ b/components/schemas/stacks/spec/scale/StackContainerScaleThresholdRam.yml
@@ -15,6 +15,5 @@ properties:
       - used
     properties:
       used:
-        type: string
+        $ref: ../../../ByteSize.yml
         description: The limit (maximum) amount of RAM each instance of the given container can use before triggering a scaling event.
-        example: "1G, 2M"

--- a/components/schemas/stacks/spec/services/loadbalancer/types/DefaultLbType.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/DefaultLbType.yml
@@ -17,9 +17,7 @@ properties:
     enum:
       - "default"
   details:
-    allOf:
-      - type: object
-        nullable: true
-      - oneOf:
-          - $ref: ../../../../../../../components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyConfig.yml
-          - $ref: ../../../../../../../components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfig.yml
+    oneOf:
+      - type: "null"
+      - $ref: ../../../../../../../components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyConfig.yml
+      - $ref: ../../../../../../../components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfig.yml

--- a/components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyConfigSet.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyConfigSet.yml
@@ -27,14 +27,16 @@ properties:
           - tcp
           - http
       max_connections:
-        type: integer
-        nullable: true
+        type:
+          - "integer"
+          - "null"
         description:
           The number of simultaneous connections that can be processed
           at a time.
       timeouts:
-        type: object
-        nullable: true
+        type:
+          - "object"
+          - "null"
         description:
           Various options for handling timeouts when communicating with
           the client.
@@ -45,30 +47,34 @@ properties:
           - http_request_ms
         properties:
           client_secs:
-            type: integer
-            nullable: true
+            type:
+              - "integer"
+              - "null"
             description:
               The number of seconds the load balancer will wait for a response
               from a client before disconnecting.
           client_fin_ms:
-            type: integer
-            nullable: true
+            type:
+              - "integer"
+              - "null"
             description:
               The number of milliseconds the load balancer will wait for
               a client to send it data when one direction is already closed. This
               is particularly useful to avoid keeping connections in a waiting state
               for too long when clients do not disconnect cleanly.
           http_keep_alive_ms:
-            type: integer
-            nullable: true
+            type:
+              - "integer"
+              - "null"
             description:
               The number of milliseconds the load balancer will wait for
               a new HTTP request to start coming after a response was set. See the
               [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-timeout%20http-request)
               for more information. (`http` mode only)
           http_request_ms:
-            type: integer
-            nullable: true
+            type:
+              - "integer"
+              - "null"
             description:
               The number of milliseconds the load balancer will wait for
               a complete HTTP request. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-timeout%20http-request)
@@ -100,8 +106,9 @@ properties:
           - first
           - source
       timeouts:
-        type: object
-        nullable: true
+        type:
+          - "object"
+          - "null"
         description:
           Various options for handling timeouts when communicating with
           a container instance behind the load balancer.
@@ -113,38 +120,43 @@ properties:
           - tunnel_secs
         properties:
           server_secs:
-            type: integer
-            nullable: true
+            type:
+              - "integer"
+              - "null"
             description:
               The number of seconds the load balancer will wait for a response
               from the container instance. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-timeout%20server)
               for more information.
           server_fin_ms:
-            type: integer
-            nullable: true
+            type:
+              - "integer"
+              - "null"
             description:
               The number of milliseconds the load balancer will wait for
               the server to send data when one direction is already closed. See the
               [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-timeout%20server-fin)
               for more information.
           connect_ms:
-            type: integer
-            nullable: true
+            type:
+              - "integer"
+              - "null"
             description:
               The number of milliseconds the load balancer will wait for
               a successful connection to a container instance. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-timeout%20connect)
               for more information.
           queue_ms:
-            type: integer
-            nullable: true
+            type:
+              - "integer"
+              - "null"
             description:
               The number of milliseconds the load balancer will hold connections
               in a queue when the maximum number of connections has been reached.
               See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-timeout%20queue)
               for more information.
           tunnel_secs:
-            type: integer
-            nullable: true
+            type:
+              - "integer"
+              - "null"
             description:
               The number of milliseconds the load balancer will allow for
               inactivity on a bidirectional tunnel. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-timeout%20tunnel)

--- a/components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyLbType.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/haproxy/HaProxyLbType.yml
@@ -17,7 +17,8 @@ properties:
     enum:
       - "haproxy"
   details:
-    type: object
-    nullable: true
+    type:
+      - "object"
+      - "null"
     allOf:
       - $ref: HaProxyConfig.yml

--- a/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfig.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfig.yml
@@ -55,8 +55,9 @@ properties:
                       type: integer
                       description: The port inbound trafic is accepted on.
                     tls:
-                      nullable: true
-                      type: object
+                      type:
+                        - "object"
+                        - "null"
                       description: TLS termination configuration. If null, the platform will use the default configuration. Port 443 by default has TLS termination enabled.
                       required:
                         - enable
@@ -68,8 +69,9 @@ properties:
                           type: boolean
                           description: Allow TLS connections and enable TLS termination.
                         server_name:
-                          type: string
-                          nullable: true
+                          type:
+                            - "string"
+                            - "null"
                           description: |
                             [Advanced] Change the domain the controller listens on.
                         allow_insecure:

--- a/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfigRouter.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfigRouter.yml
@@ -14,14 +14,16 @@ properties:
       - internal_port
     properties:
       domains:
-        nullable: true
-        type: array
+        type:
+          - "array"
+          - "null"
         description: The specific domains to match against.
         items:
           type: string
       internal_port:
-        nullable: true
-        type: array
+        type:
+          - "array"
+          - "null"
         description: The specific ports to match against.
         items:
           type: integer

--- a/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbType.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbType.yml
@@ -17,7 +17,6 @@ properties:
     enum:
       - "v1"
   details:
-    type: object
-    nullable: true
-    allOf:
+    anyOf:
+      - type: "null"
       - $ref: V1LbConfig.yml

--- a/components/schemas/stacks/spec/services/loadbalancer/types/v1/routers/HttpRouterConfig.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/v1/routers/HttpRouterConfig.yml
@@ -16,8 +16,9 @@ properties:
       - forward
     properties:
       redirect:
-        nullable: true
-        type: object
+        type:
+          - "object"
+          - "null"
         required:
           - auto_https_redirect
           - port
@@ -26,30 +27,36 @@ properties:
         description: Defines a built-in redirect for HTTP mode routers
         properties:
           auto_https_redirect:
-            nullable: true
-            type: boolean
+            type:
+              - "boolean"
+              - "null"
             description: If enabled and a sibling controller exists for port 443, requests will be auto redirected to it. Essentially sets up automatic TLS redirection for this router.
           port:
-            nullable: true
-            type: integer
+            type:
+              - "integer"
+              - "null"
             description: The port to redirect traffic to.
           scheme:
-            nullable: true
-            type: string
+            type:
+              - "string"
+              - "null"
             description: The scheme to redirect to. (i.e. `https`)
           url:
-            nullable: true
-            type: string
+            type:
+              - "string"
+              - "null"
             description: A specific URL to redirect to.
       forward:
-        nullable: true
-        type: object
+        type:
+          - "object"
+          - "null"
         required:
           - scheme
         properties:
           scheme:
-            nullable: true
-            type: string
+            type:
+              - "string"
+              - "null"
             enum:
               - tcp
               - http

--- a/components/schemas/stacks/spec/services/loadbalancer/types/v1/transports/HttpTransportConfig.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/v1/transports/HttpTransportConfig.yml
@@ -21,6 +21,7 @@ properties:
         description: Defines extra configuration options connections to the load balancer
         properties:
           max_idle_conns_per_connection:
-            nullable: true
-            type: integer
+            type:
+              - "integer"
+              - "null"
             description: Maximum number of simultaneous connections (via http/2) per connection.

--- a/internal/api.yml
+++ b/internal/api.yml
@@ -1,5 +1,5 @@
 ---
-openapi: 3.0.0
+openapi: 3.1.0
 servers:
   - description: Cycle Public API
     # https://github.com/whatwg/url/issues/577

--- a/json-schema.json
+++ b/json-schema.json
@@ -1,0 +1,73 @@
+{
+  "title": "Stack",
+  "type": "object",
+  "description": "Stacks are a way to orchestrate multiple containers atomically and automatically.",
+  "required": [
+    "id",
+    "identifier",
+    "name",
+    "hub_id",
+    "creator",
+    "source",
+    "state",
+    "events"
+  ],
+  "properties": {
+    "id": {
+      "$ref": "../ID.yml"
+    },
+    "identifier": {
+      "$ref": "../Identifier.yml",
+      "description": "A human readable slugged identifier for this stack."
+    },
+    "name": {
+      "type": "string",
+      "description": "A user defined name for the stack resource."
+    },
+    "hub_id": {
+      "$ref": "../HubID.yml"
+    },
+    "creator": {
+      "$ref": "../common/UserScope.yml"
+    },
+    "source": {
+      "$ref": "./StackSource.yml"
+    },
+    "state": {
+      "$ref": "./StackState.yml"
+    },
+    "events": {
+      "title": "StackEvents",
+      "type": "object",
+      "description": "A collection of timestamps for each event in the Stacks lifetime.",
+      "required": [
+        "created",
+        "updated",
+        "deleted",
+        "last_build"
+      ],
+      "properties": {
+        "created": {
+          "description": "The timestamp of when the stack was created.",
+          "$ref": "../DateTime.yml"
+        },
+        "updated": {
+          "description": "The timestamp of when the stack was updated.",
+          "$ref": "../DateTime.yml"
+        },
+        "deleted": {
+          "description": "The timestamp of when the stack was deleted.",
+          "$ref": "../DateTime.yml"
+        },
+        "last_build": {
+          "description": "The timestamp for the last build of the stack.",
+          "$ref": "../DateTime.yml"
+        }
+      }
+    },
+    "meta": {
+      "$ref": "./StackMeta.yml"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/public/api.yml
+++ b/public/api.yml
@@ -1,5 +1,5 @@
 ---
-openapi: 3.0.0
+openapi: 3.1.0
 servers:
   - description: Cycle Public API
     url: https://api.cycle.io

--- a/public/paths/environments/environments.yml
+++ b/public/paths/environments/environments.yml
@@ -132,8 +132,9 @@ post:
             features:
               $ref: ../../../components/schemas/environments/Features.yml
             stack:
-              type: object
-              nullable: true
+              type:
+                - "object"
+                - "null"
               description: An object representing the associated stack.
               required:
                 - id

--- a/public/paths/environments/scoped-variable.yml
+++ b/public/paths/environments/scoped-variable.yml
@@ -60,8 +60,9 @@ patch:
               type: string
               description: An identifier, similar to a key in an environment variable.  Its used when envoking the scoped variable.
             secret:
-              nullable: true
-              type: object
+              type:
+                - "object"
+                - "null"
               description: An object with information about the encryption of the scoped variable.
               required:
                 - encrypted

--- a/public/paths/environments/scoped-variables.yml
+++ b/public/paths/environments/scoped-variables.yml
@@ -31,7 +31,6 @@ get:
             description: |
               `filter[state]=value1,value2` state filtering will allow you to filter by the scoped variable's current state.
     - $ref: ../../../components/parameters/SortParam.yml
-
     - $ref: ../../../components/parameters/PageParam.yml
   summary: List Scoped Variables
   description: Requires the `scoped-variables-view` capability.
@@ -80,8 +79,9 @@ post:
               type: string
               description: An identifier, similar to a key in an environment variable.  Its used when envoking the scoped variable.
             secret:
-              nullable: true
-              type: object
+              type:
+                - "object"
+                - "null"
               description: An object with information about the encryption of the scoped variable.
               required:
                 - encrypted

--- a/public/paths/environments/services/lb/tasks.yml
+++ b/public/paths/environments/services/lb/tasks.yml
@@ -30,8 +30,9 @@ post:
               type: object
               properties:
                 high_availability:
-                  nullable: true
-                  type: boolean
+                  type:
+                    - "boolean"
+                    - "null"
                   description: A boolean where `true` represents the desire to run the environment load balancer service in high availability mode.
                 config:
                   $ref: ../../../../../components/schemas/environments/services/lb/LoadBalancerConfig.yml

--- a/public/paths/hubs/keys/key.yml
+++ b/public/paths/hubs/keys/key.yml
@@ -61,8 +61,9 @@ patch:
                   items:
                     $ref: ../../../../components/schemas/common/Capability.yml
             ips:
-              type: array
-              nullable: true
+              type:
+                - "array"
+                - "null"
               description: An array of approved IPs from which this API Key can be used.
               items:
                 type: string

--- a/public/paths/hubs/keys/keys.yml
+++ b/public/paths/hubs/keys/keys.yml
@@ -58,8 +58,9 @@ post:
                   items:
                     $ref: ../../../../components/schemas/common/Capability.yml
             ips:
-              type: array
-              nullable: true
+              type:
+                - "array"
+                - "null"
               description: An array of approved IPs from which this API Key can be used.
               items:
                 type: string

--- a/public/paths/images/sources/source.yml
+++ b/public/paths/images/sources/source.yml
@@ -87,8 +87,9 @@ patch:
                 - description
               properties:
                 description:
-                  type: string
-                  nullable: true
+                  type:
+                    - "object"
+                    - "null"
                   description: A description of the image source.
   responses:
     200:

--- a/public/paths/images/sources/sources.yml
+++ b/public/paths/images/sources/sources.yml
@@ -109,8 +109,9 @@ post:
                 - description
               properties:
                 description:
-                  type: string
-                  nullable: true
+                  type:
+                    - "string"
+                    - "null"
                   description: A description of the image source.
   responses:
     201:

--- a/schemas/stack-spec.json
+++ b/schemas/stack-spec.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/cycleplatform/api-spec/main/schemas/stack-schema.json",
+  "title": "Cycle Stack File",
+  "description": "A stack file for use with https://cycle.io",
+  "type": "object",
+  "required": ["version", "containers"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "A string defining the version of the stack spec."
+    },
+    "about": {
+      "type": "object",
+      "description": "Information about the stack.",
+      "required": ["description", "version"],
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Internal version information set by the user."
+        },
+        "description": {
+          "type": "string",
+          "description": "Information describing the stack."
+        }
+      }
+    },
+    "tests": {
+      "type": "array",
+      "items": {
+        "$ref": "StackSpecTestContainer.yml"
+      }
+    },
+    "containers": {
+      "$ref": "./StackContainer.yml"
+    },
+    "services": {
+      "title": "StackSpecServices",
+      "type": "object",
+      "properties": {
+        "loadbalancer": {
+          "$ref": "services/loadbalancer/StackSpecLoadBalancerConfig.yml"
+        },
+        "vpn": {
+          "type": "object",
+          "required": ["auth", "allow_internet"],
+          "properties": {
+            "auth": {
+              "type": "object",
+              "required": ["cycle_accounts", "vpn_accounts"],
+              "properties": {
+                "webhook": {
+                  "type": "string"
+                },
+                "cycle_accounts": {
+                  "type": "boolean"
+                },
+                "vpn_accounts": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "allow_internet": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "annotations": {
+      "type": "object",
+      "description": "Additional meta info about the stack.",
+      "additionalProperties": {}
+    }
+  }
+}


### PR DESCRIPTION
This PR will upgrade the spec to OpenAPI 3.1.0. Now that tooling is getting more mature, there are a few features in the new version we'd like to take advantage of. This brings all API files in-line with 3.1.0.