### PR TITLE
update create server to return to JobDescriptor

### DIFF
--- a/public/paths/infrastructure/servers/servers.yml
+++ b/public/paths/infrastructure/servers/servers.yml
@@ -147,7 +147,7 @@ post:
                           type: string
   responses:
     201:
-      description: Returns a single server resource.
+      description: Returns a task descriptor.
       content:
         application/json:
           schema:
@@ -155,6 +155,6 @@ post:
             type: object
             properties:
               data:
-                $ref: ../../../../components/schemas/infrastructure/servers/Server.yml
+                $ref: ../../../../components/schemas/jobs/TaskDescriptor.yml
     default:
       $ref: ../../../../components/responses/errors/DefaultError.yml

--- a/public/paths/infrastructure/servers/servers.yml
+++ b/public/paths/infrastructure/servers/servers.yml
@@ -146,7 +146,7 @@ post:
                         zone:
                           type: string
   responses:
-    201:
+    202:
       description: Returns a task descriptor.
       content:
         application/json:


### PR DESCRIPTION
Create Server does not return a server resource, but a job descriptor.  Multiple servers can be created with a single job, so it's not possible to return a single server resource.