### PR TITLE
update provider api calls to use providerIdentifier

### DIFF
--- a/components/schemas/images/origins/dockerHub/DockerHubOrigin.yml
+++ b/components/schemas/images/origins/dockerHub/DockerHubOrigin.yml
@@ -13,13 +13,9 @@ properties:
     type: object
     required:
       - target
-      - existing
     properties:
       existing:
-        type: object
-        nullable: true
-        allOf:
-          - $ref: ../ExistingSource.yml
+        $ref: ../ExistingSource.yml
       target:
         type: string
         description: The DockerHub target string. ex - `mysql:5.7`

--- a/components/schemas/images/origins/dockerRegistry/DockerRegistryOrigin.yml
+++ b/components/schemas/images/origins/dockerRegistry/DockerRegistryOrigin.yml
@@ -14,13 +14,9 @@ properties:
     required:
       - target
       - url
-      - existing
     properties:
       existing:
-        type: object
-        nullable: true
-        allOf:
-          - $ref: ../ExistingSource.yml
+        $ref: ../ExistingSource.yml
       target:
         type: string
         description: The image name on the registry.

--- a/components/schemas/images/origins/ociRegistry/OciRegistryOrigin.yml
+++ b/components/schemas/images/origins/ociRegistry/OciRegistryOrigin.yml
@@ -15,13 +15,9 @@ properties:
       - target
       - url
       - auth
-      - existing
     properties:
       existing:
-        type: object
-        nullable: true
-        allOf:
-          - $ref: ../ExistingSource.yml
+        $ref: ../ExistingSource.yml
       target:
         type: string
         description: The image name on the registry.

--- a/components/schemas/infrastructure/providers/ProviderMeta.yml
+++ b/components/schemas/infrastructure/providers/ProviderMeta.yml
@@ -6,3 +6,5 @@ properties:
     type: array
     items:
       $ref: "./InfrastructureProviderLocation.yml"
+  identifier:
+    type: string

--- a/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfig.yml
+++ b/components/schemas/stacks/spec/services/loadbalancer/types/v1/V1LbConfig.yml
@@ -49,7 +49,6 @@ properties:
                   description: Defines how traffic gets into the load balancer.
                   required:
                     - port
-                    - tls
                   properties:
                     port:
                       type: integer

--- a/public/api.yml
+++ b/public/api.yml
@@ -309,17 +309,17 @@ paths:
   "/v1/infrastructure/summary":
     "$ref": "./paths/infrastructure/summary.yml"
   # Providers
-  "/v1/infrastructure/providers/native":
+  "/v1/infrastructure/native-providers":
     "$ref": "./paths/infrastructure/providers/native.yml"
-  "/v1/infrastructure/providers/{providerId}/servers":
+  "/v1/infrastructure/providers/{providerIdentifier}/servers":
     "$ref": "./paths/infrastructure/providers/servers.yml"
-  "/v1/infrastructure/providers/{providerId}/locations":
+  "/v1/infrastructure/providers/{providerIdentifier}/locations":
     "$ref": "./paths/infrastructure/providers/locations.yml"
   "/v1/infrastructure/providers":
     "$ref": "./paths/infrastructure/providers/providers.yml"
-  "/v1/infrastructure/providers/{providerId}":
+  "/v1/infrastructure/providers/{providerIdentifier}":
     "$ref": "./paths/infrastructure/providers/provider.yml"
-  "/v1/infrastructure/providers/{providerId}/tasks":
+  "/v1/infrastructure/providers/{providerIdentifier}/tasks":
     "$ref": "./paths/infrastructure/providers/tasks.yml"
   "/v1/infrastructure/auto-scale/groups":
     "$ref": "./paths/infrastructure/auto-scale/groups/groups.yml"

--- a/public/paths/infrastructure/providers/locations.yml
+++ b/public/paths/infrastructure/providers/locations.yml
@@ -3,7 +3,7 @@ get:
   tags:
     - Providers
   parameters:
-    - name: providerId
+    - name: providerIdentifier
       description: The identifier for the given provider. Can be `aws`, `gcp`, `equinix-metal`, `vultr`.
       in: path
       required: true

--- a/public/paths/infrastructure/providers/locations.yml
+++ b/public/paths/infrastructure/providers/locations.yml
@@ -4,7 +4,7 @@ get:
     - Providers
   parameters:
     - name: providerIdentifier
-      description: The identifier for the given provider. Can be `aws`, `gcp`, `equinix-metal`, `vultr`.
+      description: The identifier for the given provider. Example `gcp`, `equinix-metal`, `a-<abstract-provider-id>`, etc.
       in: path
       required: true
       schema:

--- a/public/paths/infrastructure/providers/provider.yml
+++ b/public/paths/infrastructure/providers/provider.yml
@@ -4,7 +4,7 @@ get:
     - Providers
   parameters:
     - name: providerIdentifier
-      description: The ID for the given provider.
+      description: The identifier for the given provider. Example `gcp`, `equinix-metal`, `a-<abstract-provider-id>`, etc.
       in: path
       required: true
       schema:
@@ -30,7 +30,7 @@ patch:
     - Providers
   parameters:
     - name: providerIdentifier
-      description: The identifier for the given provider. Can be `aws`, `gcp`, `equinix-metal`, `vultr`.
+      description: The identifier for the given provider. Example `gcp`, `equinix-metal`, `a-<abstract-provider-id>`, etc.
       in: path
       required: true
       schema:
@@ -96,7 +96,7 @@ delete:
     - Providers
   parameters:
     - name: providerIdentifier
-      description: The identifier for the given provider. Can be `aws`, `gcp`, `equinix-metal`, `vultr`.
+      description: The identifier for the given provider. Example `gcp`, `equinix-metal`, `a-<abstract-provider-id>`, etc.
       in: path
       required: true
       schema:

--- a/public/paths/infrastructure/providers/provider.yml
+++ b/public/paths/infrastructure/providers/provider.yml
@@ -3,7 +3,7 @@ get:
   tags:
     - Providers
   parameters:
-    - name: providerId
+    - name: providerIdentifier
       description: The ID for the given provider.
       in: path
       required: true
@@ -29,8 +29,8 @@ patch:
   tags:
     - Providers
   parameters:
-    - name: providerId
-      description: The ID for the given provider.
+    - name: providerIdentifier
+      description: The identifier for the given provider. Can be `aws`, `gcp`, `equinix-metal`, `vultr`.
       in: path
       required: true
       schema:
@@ -95,8 +95,8 @@ delete:
   tags:
     - Providers
   parameters:
-    - name: providerId
-      description: The ID for the given provider.
+    - name: providerIdentifier
+      description: The identifier for the given provider. Can be `aws`, `gcp`, `equinix-metal`, `vultr`.
       in: path
       required: true
       schema:

--- a/public/paths/infrastructure/providers/providers.yml
+++ b/public/paths/infrastructure/providers/providers.yml
@@ -20,6 +20,7 @@ get:
             - node
             - instances_count
             - locations
+            - identifier
     - name: filter
       in: query
       # Deep nested arrays are undefined https://github.com/OAI/OpenAPI-Specification/issues/1706

--- a/public/paths/infrastructure/providers/servers.yml
+++ b/public/paths/infrastructure/providers/servers.yml
@@ -3,7 +3,7 @@ get:
   tags:
     - Providers
   parameters:
-    - name: providerId
+    - name: providerIdentifier
       description: The identifier for the given provider. Can be `aws`, `gcp`, `equinix-metal`, `vultr`.
       in: path
       required: true

--- a/public/paths/infrastructure/providers/servers.yml
+++ b/public/paths/infrastructure/providers/servers.yml
@@ -4,7 +4,7 @@ get:
     - Providers
   parameters:
     - name: providerIdentifier
-      description: The identifier for the given provider. Can be `aws`, `gcp`, `equinix-metal`, `vultr`.
+      description: The identifier for the given provider. Example `gcp`, `exuinix-metal`, `a-<abstract-provider-id>`, etc.
       in: path
       required: true
       schema:

--- a/public/paths/infrastructure/providers/tasks.yml
+++ b/public/paths/infrastructure/providers/tasks.yml
@@ -4,7 +4,7 @@ post:
   operationId: "createProviderJob"
   parameters:
     - name: providerIdentifier
-      description: The ID for the given provider.
+      description: The identifier for the given provider. Example `gcp`, `equinix-metal`, `a-<abstract-provider-id>`, etc.
       in: path
       required: true
       schema:

--- a/public/paths/infrastructure/providers/tasks.yml
+++ b/public/paths/infrastructure/providers/tasks.yml
@@ -3,7 +3,7 @@ post:
     - Providers
   operationId: "createProviderJob"
   parameters:
-    - name: providerId
+    - name: providerIdentifier
       description: The ID for the given provider.
       in: path
       required: true


### PR DESCRIPTION
Platform has been updated to globally use providerIdentifier for:
- getProvider
- patchProvider
- deleteProvider
- getServers
- postTask - /providers
- getLocations

Previously, some of these api calls used provider id