### PR TITLE
add shared directory to container.config.runtime

### DIFF
--- a/components/schemas/containers/config/ContainerIntegrations.yml
+++ b/components/schemas/containers/config/ContainerIntegrations.yml
@@ -117,3 +117,16 @@ properties:
         allOf:
           - $ref: ../../Duration.yml
         default: "365d"
+  shared_directories:
+    nullable: true
+    type: object
+    additionalProperties:
+      type: object
+      required:
+        - writable
+        - mount_point
+      properties:
+        writable:
+          type: boolean
+        mount_point:
+          type: string

--- a/components/schemas/containers/config/ContainerRuntime.yml
+++ b/components/schemas/containers/config/ContainerRuntime.yml
@@ -122,18 +122,20 @@ properties:
         type: boolean
       shared_directories:
         nullable: true
-        type: object
-        required:
-          - identifier
-          - writable
-          - mount_point
-        properties:
-          identifier:
-            type: string
-          writable:
-            type: boolean
-          mount_point:
-            type: string
+        type: array
+        items:
+          type: object
+          required:
+            - identifier
+            - writable
+            - mount_point
+          properties:
+            identifier:
+              type: string
+            writable:
+              type: boolean
+            mount_point:
+              type: string
   rootfs:
     type: object
     properties:

--- a/components/schemas/containers/config/ContainerRuntime.yml
+++ b/components/schemas/containers/config/ContainerRuntime.yml
@@ -113,6 +113,27 @@ properties:
         type: array
         items:
           $ref: seccomp/SeccompRule.yml
+  host:
+    nullable: true
+    type: object
+    properties:
+      shared_prod:
+        nullable: true
+        type: boolean
+      shared_directories:
+        nullable: true
+        type: object
+        required:
+          - identifier
+          - writable
+          - mount_point
+        properties:
+          identifier:
+            type: string
+          writable:
+            type: booleam
+          mount_point:
+            type: string
   rootfs:
     type: object
     properties:

--- a/components/schemas/containers/config/ContainerRuntime.yml
+++ b/components/schemas/containers/config/ContainerRuntime.yml
@@ -131,7 +131,7 @@ properties:
           identifier:
             type: string
           writable:
-            type: booleam
+            type: boolean
           mount_point:
             type: string
   rootfs:

--- a/components/schemas/containers/config/ContainerRuntime.yml
+++ b/components/schemas/containers/config/ContainerRuntime.yml
@@ -117,7 +117,7 @@ properties:
     nullable: true
     type: object
     properties:
-      shared_prod:
+      expose_proc:
         nullable: true
         type: boolean
       shared_directories:

--- a/components/schemas/containers/config/ContainerRuntime.yml
+++ b/components/schemas/containers/config/ContainerRuntime.yml
@@ -120,19 +120,6 @@ properties:
       expose_proc:
         nullable: true
         type: boolean
-      shared_directories:
-        nullable: true
-        type: object
-        additionalProperties:
-          type: object
-          required:
-            - writable
-            - mount_point
-          properties:
-            writable:
-              type: boolean
-            mount_point:
-              type: string
   rootfs:
     type: object
     properties:

--- a/components/schemas/containers/config/ContainerRuntime.yml
+++ b/components/schemas/containers/config/ContainerRuntime.yml
@@ -122,16 +122,13 @@ properties:
         type: boolean
       shared_directories:
         nullable: true
-        type: array
-        items:
+        type: object
+        additionalProperties:
           type: object
           required:
-            - identifier
             - writable
             - mount_point
           properties:
-            identifier:
-              type: string
             writable:
               type: boolean
             mount_point:

--- a/components/schemas/stacks/spec/StackContainerConfigIntegrations.yml
+++ b/components/schemas/stacks/spec/StackContainerConfigIntegrations.yml
@@ -94,3 +94,16 @@ properties:
         allOf:
           - $ref: ../../Duration.yml
         default: "365d"
+  shared_directories:
+    nullable: true
+    type: object
+    additionalProperties:
+      type: object
+      required:
+        - writable
+        - mount_point
+      properties:
+        writable:
+          type: boolean
+        mount_point:
+          type: string

--- a/components/schemas/stacks/spec/StackContainerConfigRuntime.yml
+++ b/components/schemas/stacks/spec/StackContainerConfigRuntime.yml
@@ -129,17 +129,16 @@ properties:
       shared_directories:
         nullable: true
         type: object
-        required:
-          - identifier
-          - writable
-          - mount_point
-        properties:
-          identifier:
-            type: string
-          writable:
-            type: boolean
-          mount_point:
-            type: string
+        additionalProperties:
+          type: object
+          required:
+            - writable
+            - mount_point
+          properties:
+            writable:
+              type: boolean
+            mount_point:
+              type: string
   privileged:
     type: boolean
   capabilities:

--- a/components/schemas/stacks/spec/StackContainerConfigRuntime.yml
+++ b/components/schemas/stacks/spec/StackContainerConfigRuntime.yml
@@ -126,19 +126,6 @@ properties:
       expose_proc:
         nullable: true
         type: boolean
-      shared_directories:
-        nullable: true
-        type: object
-        additionalProperties:
-          type: object
-          required:
-            - writable
-            - mount_point
-          properties:
-            writable:
-              type: boolean
-            mount_point:
-              type: string
   privileged:
     type: boolean
   capabilities:

--- a/components/schemas/stacks/spec/StackContainerConfigRuntime.yml
+++ b/components/schemas/stacks/spec/StackContainerConfigRuntime.yml
@@ -123,7 +123,7 @@ properties:
     nullable: true
     type: object
     properties:
-      shared_prod:
+      expose_proc:
         nullable: true
         type: boolean
       shared_directories:

--- a/components/schemas/stacks/spec/StackContainerConfigRuntime.yml
+++ b/components/schemas/stacks/spec/StackContainerConfigRuntime.yml
@@ -119,6 +119,27 @@ properties:
                           - SCMP_CMP_GE
                           - SCMP_CMP_GT
                           - SCMP_CMP_MASKED_EQ
+  host:
+    nullable: true
+    type: object
+    properties:
+      shared_prod:
+        nullable: true
+        type: boolean
+      shared_directories:
+        nullable: true
+        type: object
+        required:
+          - identifier
+          - writable
+          - mount_point
+        properties:
+          identifier:
+            type: string
+          writable:
+            type: booleam
+          mount_point:
+            type: string
   privileged:
     type: boolean
   capabilities:

--- a/components/schemas/stacks/spec/StackContainerConfigRuntime.yml
+++ b/components/schemas/stacks/spec/StackContainerConfigRuntime.yml
@@ -137,7 +137,7 @@ properties:
           identifier:
             type: string
           writable:
-            type: booleam
+            type: boolean
           mount_point:
             type: string
   privileged:

--- a/public/paths/infrastructure/providers/provider.yml
+++ b/public/paths/infrastructure/providers/provider.yml
@@ -9,6 +9,21 @@ get:
       required: true
       schema:
         type: string
+    - name: meta
+      in: query
+      required: false
+      description:
+        A comma separated list of meta values. Meta values will show up under a resource's
+        `meta` field. In the case of applying a meta to a collection of resources, each
+        resource will have it's own relevant meta data. In some rare cases, meta may not
+        apply to individual resources, and may appear in the root document. These will be
+        clearly labeled.
+      schema:
+        type: array
+        items:
+          type: string
+          enum:
+            - identifier
   summary: Fetch Provider
   description: Requires the `infrastructure-providers-view` capability.
   responses:


### PR DESCRIPTION
Added host struct to container.config.runtime.

Added shared directory struct to container.config.integrations

This will allow containers on the same server to have a shared directory (cache) that they all have access to with little latency.