### PR TITLE
Add lookup endpoint to api spec

### DIFF
--- a/public/api.yml
+++ b/public/api.yml
@@ -407,6 +407,9 @@ paths:
   # Security
   "/v1/security/report":
     $ref: paths/security/report.yml
+  # Utils
+  "/v1/utils/lookup":
+    $ref: paths/utils/resource/lookup.yml
 components:
   securitySchemes:
     bearerAuth:

--- a/public/paths/utils/resource/lookup.yml
+++ b/public/paths/utils/resource/lookup.yml
@@ -1,0 +1,43 @@
+get:
+  operationId: "lookupIdentifier"
+  tags:
+    - Utility
+  summary: Look up a resource identifier
+  description: Given a (base64) resource identifier string, returns the ID of the targeted resource
+  parameters:
+    - name: identifier
+      in: query
+      required: true
+      example: "cltr:production/environment:654d4e848924c1c445c3635a/container:api"
+      description: A base64 encoded resource identifier string.
+      schema:
+        type: string
+    - name: desired-component
+      in: query
+      required: true
+      description: The type of resource to lookup from the identifier string.
+      schema:
+        type: string
+        enum:
+          - cluster
+          - environment
+          - image-source
+          - stack
+          - server
+          - container
+  responses:
+    200:
+      description: Returns the ID of the requested resource from the identifier string.
+      content:
+        application/json:
+          schema:
+            title: "ResourceLookup"
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  id:
+                    type: string
+    default:
+      $ref: ../../../../components/responses/errors/DefaultError.yml


### PR DESCRIPTION
Adds support for resource identifier string lookups:

`/v1/utils/lookup?identifier=<base64-resource-identifier>&desired-component=<string>` 

- Where `identifier` is a base-64'd resource identifier string. For example: `cluster:production/environment:654d4e848924c1c445c3635a/container:api` or `cntr:api/env:production/clst:production`
- `desired-component` is the type of resource you want to pull the ID for.

This endpoint will return a response in the shape of:
```
{
  "data": {
    "id": <id>
  }
}
```