### PR TITLE
Cleanup incorrect fields

### DIFF
--- a/components/schemas/containers/instances/Instance.yml
+++ b/components/schemas/containers/instances/Instance.yml
@@ -14,6 +14,7 @@ required:
   - ready_state
   - hostname
   - migration
+  - purge_time
   - service
   - state
   - autoscale
@@ -126,8 +127,11 @@ properties:
         type: boolean
         description: A boolean where true represents the volumes for the instance should be copied to the new server as well.
   purge_time:
+    nullable: true
+    type: string
     description: If the instance was purged, the timestamp of when that happened.
-    $ref: ../../DateTime.yml
+    allOf:
+      - $ref: ../../DateTime.yml
   service:
     type: string
     description: If the instance is an instance of a service container that will be denoted here.

--- a/components/schemas/containers/instances/InstanceIncludes.yml
+++ b/components/schemas/containers/instances/InstanceIncludes.yml
@@ -1,13 +1,6 @@
 title: InstanceIncludes
 description: A resource associated with an instance.
 type: object
-required:
-  - creator
-  - servers
-  - locations
-  - providers
-  - containers
-  - environments
 properties:
   creators:
     "$ref": "../../includes/CreatorInclude.yml"

--- a/components/schemas/infrastructure/servers/ServerFeatures.yml
+++ b/components/schemas/infrastructure/servers/ServerFeatures.yml
@@ -9,5 +9,6 @@ properties:
     type: boolean
     description: A boolean where true means the server accepts incoming SFTP connections through the remote volume integration.
   base_volume_gb:
+    nullable: true
     type: integer
     description: The size of the base volume (where Cycle stores container images on this server).

--- a/public/paths/containers/instances/instances.yml
+++ b/public/paths/containers/instances/instances.yml
@@ -12,6 +12,7 @@ get:
     - name: include
       in: query
       required: false
+      explode: false
       description:
         A comma separated list of include values. Included resources will show
         up under the root document's `include` field, with the key being the id of the included


### PR DESCRIPTION
Some additional minor corrections to the spec on incorrect fields. Of note, it turns out in the OpenAPI spec, that 'explode: true' is the default for query params with array values. This means it's not technically correct for Cycle's API without 'explode: false' on things like includes. We'll need to later update all of these (and perhaps standardize?) to make this accurate. I noticed this while implementing our CLI, where only the first includes value was being respected.

