### PR TITLE
Update autoscale_group on containers to be nullable

### DIFF
--- a/components/schemas/containers/config/ContainerScale.yml
+++ b/components/schemas/containers/config/ContainerScale.yml
@@ -9,6 +9,7 @@ required:
 properties:
   autoscale_group:
     type: string
+    nullable: true
     description: The autoscaling group describes which servers should be deployed
   instances:
     type: object

--- a/components/schemas/stacks/spec/StackContainerConfigScaling.yml
+++ b/components/schemas/stacks/spec/StackContainerConfigScaling.yml
@@ -9,6 +9,7 @@ required:
 properties:
   autoscale_group:
     type: string
+    nullable: true
     description: The autoscaling group describes which servers should be deployed
   instances:
     type: object


### PR DESCRIPTION
Updates `autoscale_group` on both container config & stack definition to be nullable.