### PR TITLE
Correct bug in scoped variable access

### DIFF
--- a/components/schemas/scoped-variables/ScopedVariableAccess.yml
+++ b/components/schemas/scoped-variables/ScopedVariableAccess.yml
@@ -13,7 +13,7 @@ properties:
     type: object
     properties:
       duration:
-        type: object
+        type: string
         description: Duration is a time string that the internal API will serve that variable after runtime starts.
         nullable: true
         anyOf:

--- a/components/schemas/scoped-variables/ScopedVariableAccess.yml
+++ b/components/schemas/scoped-variables/ScopedVariableAccess.yml
@@ -22,6 +22,10 @@ properties:
     nullable: true
     description: File is an object that describes a path to mount the file to inside the container.
     type: object
+    # avoid conflicting name in ogen generator with the Decode method
+    x-ogen-properties:
+      decode:
+      name: "DecodeBase64"
     required:
       - decode
       - path

--- a/components/schemas/stacks/spec/StackSpecScopedVariable.yml
+++ b/components/schemas/stacks/spec/StackSpecScopedVariable.yml
@@ -61,6 +61,10 @@ properties:
         required:
           - decode
           - path
+        # avoid conflicting name in ogen generator with the Decode method
+        x-ogen-properties:
+          decode:
+          name: "DecodeBase64"
         properties:
           decode:
             description: When true, Cycle will interpret this variable as a base-64 encoded string, and decode it before passing it into the container.

--- a/components/schemas/stacks/spec/StackSpecScopedVariable.yml
+++ b/components/schemas/stacks/spec/StackSpecScopedVariable.yml
@@ -49,7 +49,7 @@ properties:
         type: object
         properties:
           duration:
-            type: object
+            type: string
             description: Duration is a time string that the internal API will serve that variable after runtime starts.
             nullable: true
             anyOf:


### PR DESCRIPTION
The merged type of duration on internal_api scoped variable access was incorrectly set as an object, when Duration is a string.