### PR TITLE
Add server console endpoint

### DIFF
--- a/public/api.yml
+++ b/public/api.yml
@@ -342,6 +342,8 @@ paths:
     "$ref": "./paths/infrastructure/servers/clusters.yml"
   "/v1/infrastructure/servers/{serverId}/usage":
     "$ref": "./paths/infrastructure/servers/usage.yml"
+  "/v1/infrastructure/servers/{serverId}/console":
+    "$ref": "./paths/infrastructure/servers/console.yml"
   # IPs
   "/v1/infrastructure/ips/pools":
     "$ref": "./paths/infrastructure/ips/pools.yml"

--- a/public/paths/infrastructure/servers/console.yml
+++ b/public/paths/infrastructure/servers/console.yml
@@ -1,0 +1,39 @@
+get:
+  operationId: "GetServerConsole"
+  tags:
+    - Servers
+  parameters:
+    - name: serverId
+      description: The ID of the server to connect to.
+      in: path
+      required: true
+      schema:
+        type: string
+  summary: Get the credentials to connect to a server's console.
+  description: Requires the `servers-console` capability.
+  responses:
+    200:
+      description: A successful credentials response.
+      content:
+        application/json:
+          schema:
+            title: "GetServerConsoleResponse"
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                type: object
+                title: ServerConsoleCredentials
+                required:
+                  - address
+                  - token
+                properties:
+                  address:
+                    type: string
+                    description: The URL to open a websocket to.
+                  token:
+                    type: string
+                    description: The authentication token for the console socket. It should be appended as the URL parameter "token" to the address.
+    default:
+      $ref: ../../../../components/responses/errors/DefaultError.yml


### PR DESCRIPTION
Adds `/v1/infrastructure/servers/{id}/console` endpoint. This endpoint is used to get auth credentials for streaming the stdout of a server managed by Cycle.