### PR TITLE
Deployment Spec Compliance

### DIFF
--- a/components/schemas/Version.yml
+++ b/components/schemas/Version.yml
@@ -1,0 +1,5 @@
+title: Version
+type: string
+description: |
+  A [Semantic Version](https://semver.org/) string. Follows the format vMAJOR.MINOR.PATCH-build. The `v` is required.
+example: v1.2.3-dev

--- a/components/schemas/common/Capability.yml
+++ b/components/schemas/common/Capability.yml
@@ -4,13 +4,14 @@ enum:
   # hubs
   - hubs-update
   - hubs-delete
+  - hubs-integrations-manage
+  - hubs-usage-view
   - hubs-invites-send
   - hubs-invites-manage
   - hubs-members-manage
   - hubs-members-view
   - hubs-notifications-listen
-  - hubs-integrations-manage
-  - hubs-usage-view
+
   # billing
   - billing-methods-manage
   - billing-invoices-view
@@ -18,71 +19,95 @@ enum:
   - billing-orders-manage
   - billing-services-view
   - billing-credits-view
+
   # sdn
-  - sdn-networks-view
   - sdn-networks-manage
+  - sdn-networks-view
+  - sdn-global-lbs-manage
+  - sdn-global-lbs-view
+
   # pipelines
   - pipelines-manage
   - pipelines-view
   - pipelines-trigger
+
   # environments
   - environments-create
   - environments-delete
   - environments-view
   - environments-update
   - environments-state
+  - environments-deployments-manage
   - environments-services-manage
-  - environments-vpn
-  - environments-vpn-manage
   - environments-scopedvariables-manage
   - environments-scopedvariables-view
+  - environments-vpn
+  - environments-vpn-manage
+
   # containers
   - containers-deploy
   - containers-view
   - containers-console
   - containers-ssh
   - containers-update
+  - containers-lock
   - containers-delete
   - containers-state
   - containers-volumes-manage
   - containers-volumes-view
-  - containers-instances-migrate
   - containers-backups-manage
   - containers-backups-view
+  - containers-instances-migrate
+
   # stacks
   - stacks-manage
   - stacks-view
   - stacks-builds-manage
   - stacks-builds-deploy
+
   # images
   - images-view
   - images-import
   - images-update
   - images-delete
-  - images-build
   - images-sources-view
   - images-sources-manage
+
   # jobs
   - jobs-view
-  # api keys
+
+  # api-keys
   - api-keys-manage
+
   # infrastructure
   - ips-manage
   - servers-provision
   - servers-view
-  - servers-update
+  - servers-console
   - servers-login
+  - servers-update
   - servers-state
   - servers-decommission
+
+  # autoscale-groups
+  - autoscale-groups-manage
+  - autoscale-groups-view
+
+  # infrastructure-providers
   - infrastructure-providers-manage
   - infrastructure-providers-view
+
   # security
   - security-view
   - security-manage
-  # monitoring
+
+  # monitor
   - monitor-view
   - monitor-manage
+
   # dns
   - dns-view
   - dns-manage
+
+  # dns-certs
   - dns-certs-view

--- a/components/schemas/containers/Deployment.yml
+++ b/components/schemas/containers/Deployment.yml
@@ -8,6 +8,6 @@ required:
   - version
 properties:
   version:
-    $ref: ../Identifier.yml
+    $ref: ../Version.yml
     description: |
-      A label representing the deployment.
+      A version string representing the deployment.

--- a/components/schemas/containers/taskActions/ReconfigureVolumes.yml
+++ b/components/schemas/containers/taskActions/ReconfigureVolumes.yml
@@ -1,4 +1,4 @@
-title: ReconfigureVolumeTask 
+title: ReconfigureVolumeTask
 type: object
 required:
   - action
@@ -7,7 +7,7 @@ properties:
   action:
     type: string
     enum:
-      - reconfigure.volumes
+      - volumes.reconfigure
     description: The action to take.
   contents:
     description: An array of volume objects to be reconfigured.

--- a/components/schemas/dns/records/RecordTypes.yml
+++ b/components/schemas/dns/records/RecordTypes.yml
@@ -105,7 +105,7 @@ properties:
         description: The value associated with the tag.
   linked:
     type: object
-    description: A Linked record is a record special to Cycle.  It represents a url that points to a specific container, however the IP address mapping in handled automatically by the platform.
+    description: A LINKED record is a record special to Cycle.  It represents a URL that points to a specific container or deployment of a container, however the IP address mapping in handled automatically by the platform.
     allOf:
       - type: object
         required:
@@ -131,4 +131,33 @@ properties:
             properties:
               container_id:
                 type: string
+                nullable: true
                 description: The ID of the container this record is related to.
+          - type: object
+            properties:
+              deployment:
+                type: object
+                nullable: true
+                description: Information about the deployment this record points to.
+                required:
+                  - environment_id
+                  - match
+                properties:
+                  environment_id:
+                    $ref: ../../ID.yml
+                    description: The ID of the environment with the deployment tag mapping we want to reference.
+                  match:
+                    type: object
+                    description: Describes which container and which tagged deployment this record should target.
+                    required:
+                      - container
+                    properties:
+                      container:
+                        $ref: ../../Identifier.yml
+                        description: The identifier of the container in the environment this record should point to.
+                      tag:
+                        type: string
+                        nullable: true
+                        description: The deployment tag that this record should point to. The tags are set on the root of an environment and map to a deployment version.
+                        allOf:
+                          - $ref: ../../Identifier.yml

--- a/components/schemas/environments/Environment.yml
+++ b/components/schemas/environments/Environment.yml
@@ -16,12 +16,11 @@ required:
   - events
   - features
   - services
-  - private_network
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: ../ID.yml
   identifier:
-    $ref: ../Identifier.yml 
+    $ref: ../Identifier.yml
     description: A human readable slugged identifier for this environment.
   name:
     type: string
@@ -30,13 +29,13 @@ properties:
     type: string
     description: The cluster this environment is associated with.
   about:
-    "$ref": "./EnvironmentAbout.yml"
+    $ref: ./EnvironmentAbout.yml
   creator:
-    "$ref": "../creators/CreatorScope.yml"
+    $ref: ../creators/CreatorScope.yml
   hub_id:
-    "$ref": "../HubID.yml"
+    $ref: ../HubID.yml
   state:
-    "$ref": "./EnvironmentState.yml"
+    $ref: ./EnvironmentState.yml
   events:
     title: EnvironmentEvents
     type: object
@@ -48,18 +47,32 @@ properties:
     properties:
       created:
         description: The timestamp of when the environment was created.
-        "$ref": "../DateTime.yml"
+        $ref: ../DateTime.yml
       updated:
         description: The timestamp of when the environment was updated.
-        "$ref": "../DateTime.yml"
+        $ref: ../DateTime.yml
       deleted:
         description: The timestamp of when the environment was deleted.
-        "$ref": "../DateTime.yml"
+        $ref: ../DateTime.yml
   features:
-    "$ref": "./Features.yml"
+    $ref: ./Features.yml
   services:
-    "$ref": "./EnvironmentServices.yml"
+    $ref: ./EnvironmentServices.yml
   private_network:
-    "$ref": "./PrivateNetwork.yml"
+    type: object
+    nullable: true
+    allOf:
+      - $ref: ./PrivateNetwork.yml
+  deployments:
+    type: object
+    nullable: true
+    description: |
+      A map of custom tags to deployment versions.
+    required:
+      - tags
+    properties:
+      tags:
+        $ref: EnvironmentDeploymentTags.yml
+
   meta:
     $ref: "./EnvironmentMeta.yml"

--- a/components/schemas/environments/EnvironmentDeploymentTags.yml
+++ b/components/schemas/environments/EnvironmentDeploymentTags.yml
@@ -1,0 +1,10 @@
+title: EnvironmentDeploymentTags
+type: object
+description: |
+  A map of custom tags to deployment versions. Allows for defining a custom, persistent tag with a changing version number. 
+  For example, `dev -> v1.2.3-dev`. This is useful when dealing with DNS LINKED records, where you always want dev.example.com to point to the 
+  `dev` version of your app within an environment, where you can continuously deploy and update it without needing to change the record. It is 
+  even more useful when you have multiple LINKED records, and you update i.e. `prod`` tag to point to a new version, all records using the `prod` tag
+  are switched at once.
+additionalProperties:
+  $ref: ../Version.yml

--- a/components/schemas/environments/PrivateNetwork.yml
+++ b/components/schemas/environments/PrivateNetwork.yml
@@ -1,12 +1,11 @@
 ---
 title: PrivateNetwork
 type: object
-nullable: true
 required:
-- vxlan_tag
-- subnet
-- ipv6
-- legacy
+  - vxlan_tag
+  - subnet
+  - ipv6
+  - legacy
 properties:
   vxlan_tag:
     type: integer
@@ -16,8 +15,7 @@ properties:
     description: The subnet ID.
   ipv6:
     allOf:
-    - description: The IPv6 interface.
-    - "$ref": "./IPNet.yml"
+      - description: The IPv6 interface.
+      - "$ref": "./IPNet.yml"
   legacy:
     $ref: "./LegacyNetwork.yml"
-

--- a/components/schemas/environments/taskActions/EnvironmentInitializeAction.yml
+++ b/components/schemas/environments/taskActions/EnvironmentInitializeAction.yml
@@ -1,0 +1,11 @@
+title: EnvironmentInitializeAction
+description: A task to initialize an environment.
+type: object
+required:
+  - action
+properties:
+  action:
+    type: string
+    enum:
+      - initialize
+    description: The name of the action to perform.

--- a/components/schemas/environments/taskActions/EnvironmentReconfigureDeploymentsAction.yml
+++ b/components/schemas/environments/taskActions/EnvironmentReconfigureDeploymentsAction.yml
@@ -1,0 +1,19 @@
+title: EnvironmentReconfigureDeploymentsAction
+description: A task to reconfigure deployment mappings on an environment.
+type: object
+required:
+  - action
+  - contents
+properties:
+  action:
+    type: string
+    enum:
+      - deployments.reconfigure
+    description: The action to take.
+  contents:
+    type: object
+    required:
+      - tags
+    properties:
+      tags:
+        $ref: ../EnvironmentDeploymentTags.yml

--- a/components/schemas/environments/taskActions/EnvironmentStartAction.yml
+++ b/components/schemas/environments/taskActions/EnvironmentStartAction.yml
@@ -1,0 +1,11 @@
+title: EnvironmentStartAction
+description: A task to start an environment.
+type: object
+required:
+  - action
+properties:
+  action:
+    type: string
+    enum:
+      - start
+    description: The name of the action to perform.

--- a/components/schemas/environments/taskActions/EnvironmentStopAction.yml
+++ b/components/schemas/environments/taskActions/EnvironmentStopAction.yml
@@ -1,0 +1,11 @@
+title: EnvironmentStopAction
+description: A task to stop an environment.
+type: object
+required:
+  - action
+properties:
+  action:
+    type: string
+    enum:
+      - stop
+    description: The name of the action to perform.

--- a/components/schemas/hubs/activity/Activity.yml
+++ b/components/schemas/hubs/activity/Activity.yml
@@ -138,6 +138,8 @@ properties:
       - environment.task.initialize
       - environment.task.start
       - environment.task.stop
+      - environment.task.deployments.reconfigure
+      - environment.deployments.reconfigure
 
       - environment.scoped-variable.delete
       - environment.scoped-variable.update
@@ -185,8 +187,8 @@ properties:
       - container.stop
       - container.task.reconfigure
       - container.reconfigure
-      - container.task.reconfigure.volumes
-      - container.reconfigure.volumes
+      - container.task.volumes.reconfigure
+      - container.volumes.reconfigure
       - container.create
       - container.restart
       - container.task.reimage
@@ -260,14 +262,15 @@ properties:
       - infrastructure.server.restart
       - infrastructure.server.compute.restart
       - infrastructure.server.compute.spawner.restart
-      - infrastructure.server.reconfigure.features
-      - infrastructure.server.reconfigure.sharedfs
+      - infrastructure.server.features.reconfigure
+      - infrastructure.server.sharedfs.reconfigure
       - infrastructure.server.provision
       - infrastructure.server.console
       - infrastructure.server.update
       - infrastructure.server.task.provision
       - infrastructure.server.ssh.token
-      - infrastructure.server.task.reconfigure.features
+      - infrastructure.server.task.features.reconfigure
+      - infrastructure.server.task.sharedfs.reconfigure
       - infrastructure.server.services.sftp.lockdown
       - infrastructure.server.services.internal-api.throttle
 

--- a/components/schemas/infrastructure/servers/taskActions/ReconfigureServer.yml
+++ b/components/schemas/infrastructure/servers/taskActions/ReconfigureServer.yml
@@ -1,25 +1,25 @@
 title: ReconfigureServerAction
-type: object 
-required: 
-- action 
-- contents 
-properties: 
-  action: 
-    type: string 
-    description: The action to take. 
-    enum: 
-      - "reconfigure.features"
-  contents: 
-    type: object 
-    description: Supplemental information needed to perform the action. 
-    required: 
-      - sftp 
-      - base_volume_gb 
-    properties: 
-      sftp: 
-        type: boolean 
-        description: A boolean where true represents the desire for the server to accept incoming SFTP requests for container volumes. 
-      base_volume_gb: 
-        type: integer 
-        description: A number in GB for how big the base volume should be.  This cannot be lower than the currently set value for the server. 
-        nullable: true 
+type: object
+required:
+  - action
+  - contents
+properties:
+  action:
+    type: string
+    description: The action to take.
+    enum:
+      - features.reconfigure
+  contents:
+    type: object
+    description: Supplemental information needed to perform the action.
+    required:
+      - sftp
+      - base_volume_gb
+    properties:
+      sftp:
+        type: boolean
+        description: A boolean where true represents the desire for the server to accept incoming SFTP requests for container volumes.
+      base_volume_gb:
+        type: integer
+        description: A number in GB for how big the base volume should be.  This cannot be lower than the currently set value for the server.
+        nullable: true

--- a/components/schemas/infrastructure/servers/taskActions/ReconfigureSharedFs.yml
+++ b/components/schemas/infrastructure/servers/taskActions/ReconfigureSharedFs.yml
@@ -8,7 +8,7 @@ properties:
     type: string
     description: The action to take.
     enum:
-      - "reconfigure.sharedfs"
+      - sharedfs.reconfigure
   contents:
     type: object
     properties:

--- a/public/api.yml
+++ b/public/api.yml
@@ -167,6 +167,8 @@ paths:
     "$ref": "./paths/environments/tasks.yml"
   "/v1/environments/{environmentId}/summary":
     "$ref": "./paths/environments/summary.yml"
+  "/v1/environments/{environmentId}/deployments":
+    "$ref": "./paths/environments/deployments.yml"
   ## Load Balancer
   "/v1/environments/{environmentId}/services/lb":
     "$ref": "./paths/environments/services/lb/lb.yml"

--- a/public/paths/containers/tasks.yml
+++ b/public/paths/containers/tasks.yml
@@ -18,11 +18,11 @@ post:
         schema:
           discriminator:
             propertyName: action
-            mapping: 
+            mapping:
               start: ../../../components/schemas/containers/taskActions/ContainerStartAction.yml
               stop: ../../../components/schemas/containers/taskActions/ContainerStopAction.yml
               reconfigure: ../../../components/schemas/containers/taskActions/ReconfigureContainer.yml
-              reconfigure.volumes: ../../../components/schemas/containers/taskActions/ReconfigureVolumes.yml
+              volumes.reconfigure: ../../../components/schemas/containers/taskActions/ReconfigureVolumes.yml
               reimage: ../../../components/schemas/containers/taskActions/Reimage.yml
               scale: ../../../components/schemas/containers/taskActions/Scale.yml
           oneOf:

--- a/public/paths/environments/deployments.yml
+++ b/public/paths/environments/deployments.yml
@@ -32,7 +32,13 @@ get:
                   type: object
                   required:
                     - containers
+                    - tags
                   properties:
+                    tags:
+                      type: array
+                      description: An array of all tags on this environment that point to this version.
+                      items:
+                        $ref: ../../../components/schemas/Identifier.yml
                     containers:
                       type: integer
                       description: The number of containers utilizing this version of this deployment.

--- a/public/paths/environments/tasks.yml
+++ b/public/paths/environments/tasks.yml
@@ -11,23 +11,24 @@ post:
       schema:
         type: string
   summary: Create Environment Job
-  description: Used to `start`, `stop`, or `delete` an environment. Requires the `environments-state` capability.
+  description: Create a job for an environment, such as 'start' or 'stop'. Requires the `environments-state` capability.
   requestBody:
     description: Parameters for creating a new environment job.
     content:
       application/json:
         schema:
-          type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - start
-                - stop
-                - initialize
-              description: The name of the action to perform.
+          discriminator:
+            propertyName: action
+            mapping:
+              start: ../../../components/schemas/environments/taskActions/EnvironmentStartAction.yml
+              stop: ../../../components/schemas/environments/taskActions/EnvironmentStopAction.yml
+              initialize: ../../../components/schemas/environments/taskActions/EnvironmentInitializeAction.yml
+              deployments.reconfigure: ../../../components/schemas/environments/taskActions/EnvironmentReconfigureDeploymentsAction.yml
+          oneOf:
+            - $ref: ../../../components/schemas/environments/taskActions/EnvironmentStartAction.yml
+            - $ref: ../../../components/schemas/environments/taskActions/EnvironmentStopAction.yml
+            - $ref: ../../../components/schemas/environments/taskActions/EnvironmentInitializeAction.yml
+            - $ref: ../../../components/schemas/environments/taskActions/EnvironmentReconfigureDeploymentsAction.yml
   responses:
     202:
       description: Returns a task descriptor.

--- a/public/paths/infrastructure/servers/tasks.yml
+++ b/public/paths/infrastructure/servers/tasks.yml
@@ -19,8 +19,8 @@ post:
           discriminator:
             propertyName: action
             mapping:
-              reconfigure.sharedfs: ../../../../components/schemas/infrastructure/servers/taskActions/ReconfigureSharedFs.yml
-              reconfigure.features: ../../../../components/schemas/infrastructure/servers/taskActions/ReconfigureServer.yml
+              sharedfs.reconfigure: ../../../../components/schemas/infrastructure/servers/taskActions/ReconfigureSharedFs.yml
+              features.reconfigure: ../../../../components/schemas/infrastructure/servers/taskActions/ReconfigureServer.yml
               restart: ../../../../components/schemas/infrastructure/servers/taskActions/RestartServer.yml
               compute.restart: ../../../../components/schemas/infrastructure/servers/taskActions/RestartCompute.yml
               compute.spawner.restart: ../../../../components/schemas/infrastructure/servers/taskActions/RestartComputeSpawner.yml


### PR DESCRIPTION
- add 'version' concept and enforce semver
- standardizes 4 'task actions' to have the verb as the suffix
- add support for 'Deployment' to Linked records (LB does not currently know what this is)
- add support for 'Deployment' to Linked records
- added a new capability
- added .tags[] to .../environments/<id>/deployments call to show which env tags exist on a deployment version