### PR TITLE
add deployment tag step

### DIFF
--- a/components/schemas/pipelines/PipelineSteps.yml
+++ b/components/schemas/pipelines/PipelineSteps.yml
@@ -19,10 +19,11 @@ discriminator:
     environment.start: ./steps/EnvironmentStartStep.yml
     environment.stop: ./steps/EnvironmentStopStep.yml
     environment.delete: ./steps/EnvironmentDeleteStep.yml
-    
+    environment.deployments.tag: ./steps/EnvironmentDeploymentsTagStep.yml
+
     stack.build.create: ./steps/StackBuildCreateStep.yml
     stack.build.generate: ./steps/StackBuildGenerateStep.yml
-    stack.build.deploy: ./steps/StackBuildDeployStep.yml 
+    stack.build.deploy: ./steps/StackBuildDeployStep.yml
 
     sleep: ./steps/SleepStep.yml
     webhook.post: ./steps/WebhookPostStep.yml
@@ -46,6 +47,7 @@ oneOf:
   - $ref: ./steps/EnvironmentStartStep.yml
   - $ref: ./steps/EnvironmentStopStep.yml
   - $ref: ./steps/EnvironmentDeleteStep.yml
+  - $ref: ./steps/EnvironmentDeploymentsTagStep.yml
 
   # stack steps
   - $ref: ./steps/StackBuildCreateStep.yml

--- a/components/schemas/pipelines/steps/EnvironmentDeploymentsTagStep.yml
+++ b/components/schemas/pipelines/steps/EnvironmentDeploymentsTagStep.yml
@@ -1,0 +1,38 @@
+title: EnvironmentDeploymentsTagStep
+type: object
+description: Settings for updating a deployment tag to another deployment version.
+required:
+  - action
+  - details
+properties:
+  identifier:
+    type: string
+    description: An identifier for the step.
+  options:
+    type: object
+    properties:
+      skip:
+        type: boolean
+  action:
+    type: string
+    description: The action that the step takes.
+    enum:
+      - environment.deployments.tag
+  details:
+    type: object
+    required:
+      - environment
+      - tag
+      - deployment
+    properties:
+      environment:
+        $ref: ../ResourceLocation.yml
+      tag:
+        $ref: ../../Identifier.yml
+      deployment:
+        type: object
+        required:
+          - version
+        properties:
+          version:
+            $ref: ../../Version.yml


### PR DESCRIPTION
Adds a new pipeline step type, `environment.deployments.tag` to enable automated deployment tag updates.