### PR TITLE
Add deployments as billing tier advanced feat. flag

### DIFF
--- a/components/schemas/billing/plans/TierPlan.yml
+++ b/components/schemas/billing/plans/TierPlan.yml
@@ -47,14 +47,14 @@ properties:
     required:
       - gpu
       - ial
-      - glb
       - autoscale
+      - deployments
     properties:
       gpu:
         type: boolean
       ial:
         type: boolean
-      glb:
+      deployments:
         type: boolean
       autoscale:
         type: boolean

--- a/components/schemas/images/origins/dockerHub/DockerHubOrigin.yml
+++ b/components/schemas/images/origins/dockerHub/DockerHubOrigin.yml
@@ -15,7 +15,10 @@ properties:
       - target
     properties:
       existing:
-        $ref: ../ExistingSource.yml
+        allOf:
+          - type: object
+            nullable: true
+          - $ref: ../ExistingSource.yml
       target:
         type: string
         description: The DockerHub target string. ex - `mysql:5.7`


### PR DESCRIPTION
Adds deployments to the advanced features section of a billing tier, since this feature is only available on certain tiers.