### PR TITLE
update webhooks options non_200 to simply "not"

### DIFF
--- a/components/schemas/pipelines/steps/webhooks/WebhookStepOptions.yml
+++ b/components/schemas/pipelines/steps/webhooks/WebhookStepOptions.yml
@@ -15,11 +15,11 @@ properties:
     nullable: true
     type: object
     required:
-      - non_200
+      - not
     properties:
-      non_200:
+      not:
         type: boolean
-        description: Fail on any non-200 status codes.
+        description: If true, will fail on any codes NOT defined in the http_codes array.
       http_codes:
         type: array
         nullable: true
@@ -30,11 +30,11 @@ properties:
     nullable: true
     type: object
     required:
-      - non_200
+      - not
     properties:
-      non_200:
+      not:
         type: boolean
-        description: Wait for interval on any non-200 response
+        description: If true, will wait on any codes NOT defined in the http_codes array.
       http_codes:
         type: array
         nullable: true


### PR DESCRIPTION
Update webhooks fail_on/wait_on struct key to be "not" rather than non_200.  This update makes the struct more flexible because you can specify any codes you'd like to fail on, or fail if NOT.