### PR TITLE
Add dynamic boolean to pipelines

### DIFF
--- a/components/schemas/pipelines/Pipeline.yml
+++ b/components/schemas/pipelines/Pipeline.yml
@@ -24,6 +24,9 @@ properties:
   disable:
     type: boolean
     description: A boolean where true signifies the pipeline is disabled.
+  dynamic:
+    type: boolean
+    description: Setting to true enables variable and other advanced logic support on this pipeline. This is a one-way toggle. Once set to true, it cannot be set back to false.
   stages:
     description: An array of stages.
     type: array

--- a/components/schemas/pipelines/Pipeline.yml
+++ b/components/schemas/pipelines/Pipeline.yml
@@ -6,6 +6,7 @@ required:
   - hub_id
   - name
   - creator
+  - dynamic
   - disable
   - events
   - state

--- a/public/paths/pipelines/pipeline.yml
+++ b/public/paths/pipelines/pipeline.yml
@@ -65,6 +65,9 @@ patch:
             name:
               type: string
               description: A name for the pipeline.
+            dynamic:
+              type: boolean
+              description: Setting to true enables variable and other advanced logic support on this pipeline. This is a one-way toggle. Once set to true, it cannot be set back to false.
             stages:
               description: An array of stages.
               type: array

--- a/public/paths/pipelines/pipelines.yml
+++ b/public/paths/pipelines/pipelines.yml
@@ -43,7 +43,6 @@ get:
             description: |
               `filter[state]=value1,value2` state filtering will allow you to filter by the pipeline's current state.
     - $ref: ../../../components/parameters/SortParam.yml
-
     - $ref: ../../../components/parameters/PageParam.yml
   summary: List Pipelines
   description: Requires the `pipelines-view` capability.
@@ -86,6 +85,9 @@ post:
               description: A name for the pipeline.
             identifier:
               $ref: ../../../components/schemas/Identifier.yml
+            dynamic:
+              type: boolean
+              description: Setting to true enables variable and other advanced logic support on this pipeline. This is a one-way toggle. Once set to true, it cannot be set back to false.
             stages:
               description: An array of stages.
               type: array


### PR DESCRIPTION
- Setting to true enables variable and other advanced logic support on this pipeline. This is a one-way toggle. Once set to true, it cannot be set back to false.