### PR TITLE
Add variable map to stacks

### DIFF
--- a/components/schemas/stacks/Stack.yml
+++ b/components/schemas/stacks/Stack.yml
@@ -14,7 +14,7 @@ properties:
   id:
     "$ref": "../ID.yml"
   identifier:
-    $ref: ../Identifier.yml 
+    $ref: ../Identifier.yml
     description: A human readable slugged identifier for this stack.
   name:
     type: string
@@ -27,6 +27,11 @@ properties:
     "$ref": "./StackSource.yml"
   state:
     "$ref": "./StackState.yml"
+  variables:
+    type: object
+    description: A map of default variable values used when building this stack. A variable can be added anywhere in a stack using the format `{{var}}` where `var` would be a key in this map.
+    additionalProperties:
+      type: string
   events:
     title: StackEvents
     type: object

--- a/public/paths/stacks/stack.yml
+++ b/public/paths/stacks/stack.yml
@@ -47,6 +47,11 @@ patch:
             name:
               type: string
               description: A name for the stack.
+            variables:
+              type: object
+              description: A map of default variable values used when building this stack. A variable can be added anywhere in a stack using the format `{{var}}` where `var` would be a key in this map.
+              additionalProperties:
+                type: string
             source:
               $ref: ../../../components/schemas/stacks/StackSource.yml
   responses:

--- a/public/paths/stacks/stacks.yml
+++ b/public/paths/stacks/stacks.yml
@@ -100,6 +100,11 @@ post:
               description: A name for the stack.
             identifier:
               $ref: ../../../components/schemas/Identifier.yml
+            variables:
+              type: object
+              description: A map of default variable values used when building this stack. A variable can be added anywhere in a stack using the format `{{var}}` where `var` would be a key in this map.
+              additionalProperties:
+                type: string
             source:
               $ref: ../../../components/schemas/stacks/StackSource.yml
   responses:


### PR DESCRIPTION
- allows for specifying default variables to the stack that will be fillled in on build
- these variables can be overridden on a per-build basis