### PR TITLE
update deployment version description

### DIFF
--- a/components/schemas/Version.yml
+++ b/components/schemas/Version.yml
@@ -1,5 +1,5 @@
 title: Version
 type: string
 description: |
-  A [Semantic Version](https://semver.org/) string. Follows the format vMAJOR.MINOR.PATCH-build. The `v` is required.
+  Version can be any string, but if it begins with a "v", semantic version will be enforces. A [Semantic Version](https://semver.org/) string. Follows the format vMAJOR.MINOR.PATCH-build.
 example: v1.2.3-dev

--- a/components/schemas/Version.yml
+++ b/components/schemas/Version.yml
@@ -1,5 +1,5 @@
 title: Version
 type: string
 description: |
-  Version can be any string, but if it begins with a "v", semantic version will be enforces. A [Semantic Version](https://semver.org/) string. Follows the format vMAJOR.MINOR.PATCH-build.
+  Version can be any string, but if it begins with a "v", semantic version will be enforced. A [Semantic Version](https://semver.org/) string. Follows the format vMAJOR.MINOR.PATCH-build.
 example: v1.2.3-dev


### PR DESCRIPTION
Semantic version format is no longer required.  It will only be enforced if the string starts with a "v".