### PR TITLE
Add new healthy deployment pipeline step

### DIFF
--- a/components/schemas/pipelines/PipelineSteps.yml
+++ b/components/schemas/pipelines/PipelineSteps.yml
@@ -24,6 +24,7 @@ discriminator:
     environment.deployment.stop: steps/EnvironmentDeploymentStopStep.yml
     environment.deployments.tag: steps/EnvironmentDeploymentsTagStep.yml
     environment.deployments.prune: steps/EnvironmentDeploymentsPruneStep.yml
+    environment.deployment.healthy.watch: steps/EnvironmentDeploymentHealthyWatchStep.yml
 
     stack.build.create: steps/StackBuildCreateStep.yml
     stack.build.generate: steps/StackBuildGenerateStep.yml
@@ -58,6 +59,7 @@ oneOf:
   - $ref: steps/EnvironmentDeploymentStopStep.yml
   - $ref: steps/EnvironmentDeploymentsTagStep.yml
   - $ref: steps/EnvironmentDeploymentsPruneStep.yml
+  - $ref: steps/EnvironmentDeploymentHealthyWatchStep.yml
 
   # stack steps
   - $ref: steps/StackBuildCreateStep.yml

--- a/components/schemas/pipelines/steps/EnvironmentDeploymentHealthyWatchStep.yml
+++ b/components/schemas/pipelines/steps/EnvironmentDeploymentHealthyWatchStep.yml
@@ -1,0 +1,42 @@
+title: EnvironmentDeploymentHealthyWatchStep
+type: object
+description: | 
+  Waits for a deployment to be considered 'healthy' before allowing the pipeline to continue.
+  A deployement is considered 'healthy' when all instances of all containers that have had a state change in the last 15 minutes
+  that have health checks defined, become healthy.
+required:
+  - action
+  - details
+properties:
+  identifier:
+    type: string
+    description: An identifier for the step.
+  options:
+    type: object
+    properties:
+      skip:
+        type: boolean
+  action:
+    type: string
+    description: The action that the step takes.
+    enum:
+      - environment.deployment.healthy.watch
+  details:
+    type: object
+    required:
+      - environment
+    properties:
+      environment:
+        $ref: ../FluidIdentifier.yml
+      tag:
+        type: string
+        nullable: true
+      version:
+        type: string
+        nullable: true
+      max_wait:
+        type: string
+        nullable: true
+        description: The maximum amount of time to wait for the deployment to become healthy before failing this step.
+        allOf:
+          - $ref: ../../Duration.yml

--- a/package.json
+++ b/package.json
@@ -8,11 +8,14 @@
     "lint:public": "npx @redocly/cli lint ./public/api.yml",
     "lint:internal": "npx @redocly/cli lint ./internal/api.yml",
     "build": "npm run build:public && npm run build:internal",
-    "build:public": "npx @redocly/cli bundle public/api.yml --output dist/public-api.yml",
-    "build:internal": "npx @redocly/cli bundle internal/api.yml --output dist/internal-api.yml",
+    "build:public": "npx @redocly/cli@1.9.0 bundle public/api.yml --output dist/public-api.yml",
+    "build:internal": "npx @redocly/cli@1.9.0 bundle internal/api.yml --output dist/internal-api.yml",
     "preview:public": "npm run build:public && npx @redocly/cli preview-docs dist/public-api.yml",
     "preview:internal": "npm run build:internal && npx @redocly/cli preview-docs dist/internal-api.yml"
   },
   "author": "Petrichor Holdings, Inc.",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@redocly/cli": "1.9.0"
+  }
 }


### PR DESCRIPTION
Adds the new `environment.deployment.healthy.watch` pipeline step, enabling a pause on a pipeline for a deployment to become healthy. This is useful for those wanting to wait to update their DNS to point to a new deployment until AFTER it has been verified as healthy.