### PR TITLE
Updates to Container meta fields

### DIFF
--- a/components/schemas/containers/ContainersMeta.yml
+++ b/components/schemas/containers/ContainersMeta.yml
@@ -4,17 +4,14 @@ description: A list of meta fields that can be applied to a container.
 properties:
   instances_count:
     "$ref": "../StateCountSummary.yml"
-  domain:
-    type: string
-    description: The FQDN for this container, if there is one.
   domains:
     type: array
+    nullable: true
     items:
       type: object
-      description: Holds domain name and record mappings.
+      description: Any associated Linked Records for this container, and their fully-qualified domain name (fqdn)
       required:
         - fqdn
-        - record
       properties:
         fqdn:
           type: string


### PR DESCRIPTION
- Remove `domain` meta field - sunsetting auto-generated domains for containers due to security reasons.
- Turn `domains` meta into a nullable array (will return null if no domains associated, despite being requested).
- Remove requirement for `record` to be present on a meta `domains` entry.