### PR TITLE
Add default hub roles to platform api

### DIFF
--- a/platform/api.yml
+++ b/platform/api.yml
@@ -516,6 +516,8 @@ paths:
     $ref: "./paths/hubs/roles/roles.yml"
   "/v1/hubs/current/roles/{roleId}":
     $ref: "./paths/hubs/roles/role.yml"
+  "/v1/hubs/current/roles/defaults":
+    $ref: "./paths/hubs/roles/defaults.yml"
 
   # --Images
   "/v1/images":

--- a/platform/paths/hubs/roles/defaults.yml
+++ b/platform/paths/hubs/roles/defaults.yml
@@ -48,4 +48,4 @@ get:
                           items:
                             $ref: ../../../../components/schemas/common/Capability.yml
     default:
-      $ref: ../../../components/responses/errors/DefaultError.yml
+      $ref: ../../../../components/responses/errors/DefaultError.yml

--- a/platform/paths/hubs/roles/defaults.yml
+++ b/platform/paths/hubs/roles/defaults.yml
@@ -1,0 +1,51 @@
+get:
+  operationId: "getDefaultHubRoles"
+  summary: List Default Hub Roles
+  tags:
+    - Hubs
+  parameters: []
+  security: []
+  responses:
+    200:
+      description: Returns a list of the default roles/capabilities for a hub.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+              - meta
+            properties:
+              data:
+                type: array
+                items:
+                  type: object
+                  title: DefaultRole
+                  required:
+                    - name
+                    - identifier
+                    - root
+                    - capabilities
+                  properties:
+                    name:
+                      type: string
+                    identifier:
+                      $ref: ../../../../components/schemas/Identifier.yml
+                    root:
+                      description: The role marked as root has full moderation control over all roles.
+                      type: boolean
+                    capabilities:
+                      type: object
+                      required:
+                        - all
+                        - specific
+                      properties:
+                        all:
+                          type: boolean
+                          description: If true, the role has all capabilities.
+                        specific:
+                          type: array
+                          items:
+                            $ref: ../../../../components/schemas/common/Capability.yml
+    default:
+      $ref: ../../../components/responses/errors/DefaultError.yml


### PR DESCRIPTION
Adds the 'default roles' endpoint, which will return the  roles originally defined on the hub.