### PR TITLE
Small fix to fix generated typescript code

### DIFF
--- a/platform/paths/environments/services/lb/tasks.yml
+++ b/platform/paths/environments/services/lb/tasks.yml
@@ -40,9 +40,7 @@ post:
                     - "null"
                   description: A boolean representing if this service container is set to autoupdate or not
                 config:
-                  anyOf:
-                    - $ref: ../../../../../components/schemas/environments/services/lb/LoadBalancerConfig.yml
-                    - type: "null"
+                  $ref: ../../../../../components/schemas/environments/services/lb/LoadBalancerConfig.yml
   responses:
     202:
       description: Returns a Job Descriptor.


### PR DESCRIPTION
The sub-type handles null already because it's always used in a place where it can be null.