### PR TITLE
Replace type (array | null) with oneOf

### DIFF
--- a/components/schemas/billing/plans/TierPlan.yml
+++ b/components/schemas/billing/plans/TierPlan.yml
@@ -77,10 +77,10 @@ properties:
     type: boolean
   hubs:
     description: An array of hub IDs with access to the tier.
-    type:
-      - array
-      - "null"
-    items:
-      $ref: ../../Identifier.yml
+    oneOf:
+      - type: array
+        items:
+          $ref: ../../Identifier.yml
+      - type: "null"
   description:
     type: string

--- a/components/schemas/environments/services/loadbalancer/config/types/v1/V1LbConfigRouter.yml
+++ b/components/schemas/environments/services/loadbalancer/config/types/v1/V1LbConfigRouter.yml
@@ -14,19 +14,19 @@ properties:
       - internal_ports
     properties:
       domains:
-        type:
-          - array
-          - "null"
         description: The specific domains to match against.
-        items:
-          type: string
+        oneOf:
+          - type: array
+            items:
+              type: string
+          - type: "null"
       internal_ports:
-        type:
-          - array
-          - "null"
         description: The specific ports to match against.
-        items:
-          type: integer
+        oneOf: 
+          - type: array
+            items:
+              type: integer
+          - type: "null"
       path:
         type:
           - string
@@ -39,18 +39,18 @@ properties:
         properties:
           include:
             description: Match any traffic that would be routed to one of these containers.
-            type:
-              - array
-              - "null"
-            items:
-              $ref: ../../../../../../HybridIdentifier.yml
+            oneOf:
+              - type: array
+                items:
+                  $ref: ../../../../../../HybridIdentifier.yml
+              - type: "null"
           exclude:
             description: Match any traffic that would NOT be routed to one of these containers.
-            type:
-              - array
-              - "null"
-            items:
-              $ref: ../../../../../../HybridIdentifier.yml
+            oneOf:
+              - type: array
+                items:
+                  $ref: ../../../../../../HybridIdentifier.yml
+              - type: "null"
   mode:
     type: string
     description: |

--- a/components/schemas/images/origins/auth/RegistryAuth.yml
+++ b/components/schemas/images/origins/auth/RegistryAuth.yml
@@ -11,4 +11,3 @@ oneOf:
   - $ref: RegistryAuthUser.yml
   - $ref: RegistryAuthProvider.yml
   - $ref: RegistryAuthWebhook.yml
-  - type: "null"

--- a/components/schemas/images/origins/ociRegistry/OciRegistryOrigin.yml
+++ b/components/schemas/images/origins/ociRegistry/OciRegistryOrigin.yml
@@ -24,4 +24,6 @@ properties:
         type: string
         description: The url of the remote registry.
       auth:
-        $ref: ../auth/RegistryAuth.yml
+        oneOf:
+          - $ref: ../auth/RegistryAuth.yml
+          - type: "null"

--- a/platform/paths/monitoring/logs/aggregate.yml
+++ b/platform/paths/monitoring/logs/aggregate.yml
@@ -33,11 +33,11 @@ post:
                     - environment
                 ids:
                   description: The ID or IDs used to narrow log aggregation.
-                  type:
-                    - array
-                    - "null"
-                  items:
-                    $ref: ../../../../components/schemas/ID.yml
+                  oneOf:
+                    - type: array
+                      items:
+                        $ref: ../../../../components/schemas/ID.yml
+                    - type: "null"
                 date_range:
                   description: The date range used to narrow log aggregation.
                   anyOf:

--- a/stackspec/schema/StackSpecScopedVariable.yml
+++ b/stackspec/schema/StackSpecScopedVariable.yml
@@ -54,9 +54,7 @@ properties:
           env_variable:
             description: Grants access to this variable from within a container as an environment variable.
             oneOf:
-              - type:
-                  - object
-                  - "null"
+              - type: object
                 required:
                   - key
                 properties:
@@ -66,6 +64,7 @@ properties:
                       - type: string
                       - $ref: StackVariable.yml
               - $ref: StackVariable.yml
+              - type: "null"
           internal_api:
             description: Grants access to this variable over the Internal API.
             oneOf:


### PR DESCRIPTION
Unclear if it's "legal" to do multiple types with an array like this. Caused some downstream issues with codegen in new RTK code generator based on oazapfts. 

This change allowed it to properly generate null for array types, but the issue persists for objects, which I'm 99% sure is completely valid. 

I have an open issue here: https://github.com/oazapfts/oazapfts/issues/612, and once that is resolved, it should be just fine at generating complex types like this and avoiding issues. 