### PR TITLE
Add endpoint for fetching platform monitor location information

### DIFF
--- a/components/schemas/monitoring/Monitor.yml
+++ b/components/schemas/monitoring/Monitor.yml
@@ -1,0 +1,30 @@
+title: Monitor
+description: >
+  A monitor used to determine latency between the public internet and a load balancer on Cycle.
+  These monitors are automatically created and managed by the platform. Information about specific monitors
+  is provided for determining the regional latencies for an environment.
+type: object
+properties:
+  node_id:
+    type: string
+    description: The ID of the node this monitor is running on.
+  country_short: 
+    type: string
+    description: The country code of where this monitor is located.
+  country:
+    type: string
+    description: The full name of the country where this monitor is located.
+  region:
+    type: string
+    description: The name of the region (state, province, prefecture, etc.) where this monitor is located.
+  city:
+    type: string
+    description: The name of the city where this monitor is located.
+  latitude:
+    type: number
+    format: float
+    description: The latitude where this monitor is located.
+  longitude:
+    type: number
+    format: float
+    description: The longitude where this monitor is located.

--- a/platform/api.yml
+++ b/platform/api.yml
@@ -617,6 +617,8 @@ paths:
     $ref: paths/monitoring/events/aggregate.yml
   "/v1/monitoring/logs/aggregate":
     $ref: paths/monitoring/logs/aggregate.yml
+  "/v1/monitoring/monitors":
+    $ref: paths/monitoring/monitors/monitors.yml
 
   # --Pipelines
   "/v1/pipelines":

--- a/platform/paths/monitoring/monitors/monitors.yml
+++ b/platform/paths/monitoring/monitors/monitors.yml
@@ -1,0 +1,25 @@
+get:
+  operationId: "getMonitoringMonitors"
+  summary: Get Monitoring Monitors
+  description: | 
+    Returns location information about the monitors used for Cycle's external monitoring service.
+    These monitors are used for determining the latency between the public internet and environment 
+    load balancers.
+  tags:
+    - Monitoring
+  responses:
+    200:
+      description: Returns and array of monitor location information.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: ../../../../components/schemas/monitoring/Monitor.yml
+    default:
+      $ref: ../../../../components/responses/errors/DefaultError.yml


### PR DESCRIPTION
Adds the `/v1/monitoring/monitors` API endpoint, for fetching monitors created and used by the platform for determining latency from various locations. This endpoint provides location information for all monitors, making it possible to determine ping latency granularly by region.