### PR TITLE
Add hub security property

### DIFF
--- a/components/schemas/hubs/Hub.yml
+++ b/components/schemas/hubs/Hub.yml
@@ -8,6 +8,7 @@ required:
   - creator
   - events
   - state
+  - security
   - integrations
   - webhooks
   - billing
@@ -26,6 +27,8 @@ properties:
     $ref: "HubEvents.yml"
   state:
     $ref: "./HubState.yml"
+  security:
+    $ref: HubSecurity.yml
   webhooks:
     $ref: HubWebhooks.yml
   billing:

--- a/components/schemas/hubs/HubSecurity.yml
+++ b/components/schemas/hubs/HubSecurity.yml
@@ -1,0 +1,9 @@
+title: HubSecurity
+type: object
+description: Security options for a hub.
+properties:
+  force_2fa:
+    type: boolean
+    description: When true, any API call for this hub from an account that does not have two-factor auth enabled will fail with a 403 error.
+required:
+  - force_2fa

--- a/platform/paths/hubs/hub.yml
+++ b/platform/paths/hubs/hub.yml
@@ -54,6 +54,8 @@ patch:
               description: A name for the hub.
             webhooks:
               $ref: ../../../components/schemas/hubs/HubWebhooks.yml
+            security:
+              $ref: ../../../components/schemas/hubs/HubSecurity.yml
   responses:
     200:
       description: Returns the updated Hub resource.


### PR DESCRIPTION
Adds the security property to hubs, with the boolean for setting two-factor auth to required for the entire hub.