### PR TITLE
Add endpoint for fetching available virtual machine IPs

### DIFF
--- a/platform/api.yml
+++ b/platform/api.yml
@@ -709,6 +709,8 @@ paths:
     $ref: paths/virtual-machines/ssh-keys/ssh-keys.yml
   "/v1/virtual-machines/ssh-keys/{sshKeyId}":
     $ref: paths/virtual-machines/ssh-keys/ssh-key.yml
+  "/v1/virtual-machines/{virtualMachineId}/available-ips":
+    $ref: "./paths/virtual-machines/available-ips.yml"
 
   # --Utility
   "/v1/utils/resource/lookup":

--- a/platform/paths/virtual-machines/available-ips.yml
+++ b/platform/paths/virtual-machines/available-ips.yml
@@ -1,0 +1,38 @@
+get:
+  operationId: "getAvailableIps"
+  tags:
+    - Virtual Machines
+  summary: List Available IP Addresses
+  description: |
+    Lists IP addresses that can be assigned to the specified virtual machine.
+
+    For an IP address to be assignable to a virtual machine, it must follow these rules:
+
+    1. The IP address must be assigned to the same location as the virtual machine.
+    2. The IP address must be from a server that supports the `gateway` service.
+    3. The IP address must be in the `available` state.
+
+    Requires the `virtual-machines-view` capability.
+  parameters:
+    - name: virtualMachineId
+      description: The ID of the virtual machine.
+      in: path
+      required: true
+      schema:
+        type: string
+  responses:
+    200:
+      description: Returns a list of IP addresses.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: ../../../components/schemas/infrastructure/ips/Ip.yml
+    default:
+      $ref: ../../../components/responses/errors/DefaultError.yml


### PR DESCRIPTION
Adds:
`/v1/virtual-machines/{virtualMachineId}/available-ips`

which is used to gather a list of IPs that can be assigned to a virtual machine.
