### PR TITLE
Add billing status endpoint to platform API

### DIFF
--- a/platform/api.yml
+++ b/platform/api.yml
@@ -306,6 +306,8 @@ paths:
     $ref: "./paths/announcements/announcements.yml"
 
   # --Billing
+  "/v1/billing/status":
+    $ref: "./paths/billing/status.yml"
   ## Credits
   "/v1/billing/credits":
     $ref: "./paths/billing/credits/credits.yml"
@@ -377,10 +379,10 @@ paths:
     $ref: "./paths/containers/instances/tasks.yml"
   "/v1/containers/{containerId}/instances/{instanceId}/volumes":
     $ref: "./paths/containers/instances/volumes.yml"
-  "/v1/containers/{containerId}/instances/{instanceId}/telemetry/resources/report":
-    $ref: paths/containers/instances/telemetry/report.yml
-  "/v1/containers/{containerId}/instances/{instanceId}/telemetry/resources/stream":
-    $ref: paths/containers/instances/telemetry/stream.yml
+  ? "/v1/containers/{containerId}/instances/{instanceId}/telemetry/resources/report"
+  : $ref: paths/containers/instances/telemetry/report.yml
+  ? "/v1/containers/{containerId}/instances/{instanceId}/telemetry/resources/stream"
+  : $ref: paths/containers/instances/telemetry/stream.yml
   "/v1/containers/{containerId}/instances/{instanceId}/console":
     $ref: "paths/containers/instances/console.yml"
   "/v1/containers/{containerId}/functions/tasks":

--- a/platform/paths/billing/status.yml
+++ b/platform/paths/billing/status.yml
@@ -1,0 +1,27 @@
+get:
+  operationId: "getBillingStatus"
+  summary: Get Billing Status
+  description: |
+    Retrieve meta details about the billing status of this Cycle core. It is unlikely that someone would need this endpoint outside 
+    of Cycle's internal teams.
+  tags:
+    - Billing
+  parameters: []
+  responses:
+    200:
+      description: Returns details about the billing status of this Cycle core.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                    description: Whether billing is enabled for this core. Generally, this will only be false for dedicated cores.
+    default:
+      $ref: ../../../components/responses/errors/DefaultError.yml


### PR DESCRIPTION
Adds `/v1/billing/status` endpoint, which is mostly intended for internal use. It gets the billing status of a Cycle core, which unless you have access to a dedicated core, will likely be useful for you.