### PR TITLE
Add deprecated field to integration definitions

### DIFF
--- a/components/schemas/hubs/integrations/IntegrationDefinition.yml
+++ b/components/schemas/hubs/integrations/IntegrationDefinition.yml
@@ -1,5 +1,5 @@
 title: IntegrationDefinition
-description: Describes an integration for a Cycle Hub that can be enabled by the Hub owner.
+description: Describes an integration for a Cycle hub that can be enabled by the hub owner.
 type: object
 required:
   - vendor
@@ -24,7 +24,7 @@ properties:
     type:
       - array
       - "null"
-    description: A list of additional features supported by this Integration.
+    description: A list of additional features supported by this integration.
     items:
       type: string
   extends:
@@ -38,7 +38,7 @@ properties:
     type:
       - object
       - "null"
-    description: Additional configuration options that are available when using this Integration. These describe additional functionality that Cycle may utilize.
+    description: Additional configuration options that are available when using this integration. These describe additional functionality that Cycle may utilize.
     properties:
       options:
         type:
@@ -103,6 +103,10 @@ properties:
     type: boolean
   usable:
     type: boolean
+    description: Whether or not this integration can be used at this time.
+  deprecated:
+    type: boolean
+    description: If true, this integration is no longer being supported and may be removed in the future. New instances of this integration will not be able to be created.
   editable:
     type: boolean
-    description: If true, the Integration can be edited. Otherwise, to make a change it will need to be deleted and recreated.
+    description: If true, the integration can be edited. Otherwise, to make a change it will need to be deleted and recreated.


### PR DESCRIPTION
Adds a new `deprecated` field to hub integrations to indicate that the integration is no longer being supported, no new instances may be created, and may be removed in the near future.