### PR TITLE
Add `configuring` state to virtual machines

### DIFF
--- a/components/schemas/vms/VirtualMachineState.yml
+++ b/components/schemas/vms/VirtualMachineState.yml
@@ -9,6 +9,7 @@ allOf:
         enum:
           - new
           - starting
+          - configuring
           - running
           - stopping
           - stopped


### PR DESCRIPTION
Adds the `configuring` state to VMs. This state signifies that the hypervisor is being configured and downloading the ISO before starting the VM. 

This state is useful especially for consumers of the API who may need to know exactly when a VM is available for logging in or is running, whereas before this was difficult to determine due to the VM going immediately into the `running` state.