### PR TITLE
overhaul the includes naming system to eliminate duplicates

### DIFF
--- a/components/schemas/CommonErrors.yml
+++ b/components/schemas/CommonErrors.yml
@@ -3,22 +3,22 @@
   content:
     application/json:
       schema:
-        "$ref": "./error/ErrorResponse.yml"
+        $ref: "./error/ErrorResponse.yml"
 "401":
   description: OAuth token is invalid.
   content:
     application/json:
       schema:
-        "$ref": "./error/ErrorResponse.yml"
+        $ref: "./error/ErrorResponse.yml"
 "404":
   description: The requested resource doesn't exist.
   content:
     application/json:
       schema:
-        "$ref": "./error/ErrorResponse.yml"
+        $ref: "./error/ErrorResponse.yml"
 "500":
   description: Indicates an issue with Cycle. Rare.
   content:
     application/json:
       schema:
-        "$ref": "./error/ErrorResponse.yml"
+        $ref: "./error/ErrorResponse.yml"

--- a/components/schemas/State.yml
+++ b/components/schemas/State.yml
@@ -6,7 +6,7 @@ required:
   - changed
 properties:
   changed:
-    "$ref": "./DateTime.yml"
+    $ref: "./DateTime.yml"
   error:
     type: object
     description: An error, if any, that has occurred for this resource.
@@ -16,4 +16,4 @@ properties:
         description: Details about the error that has occurred.
       time:
         description: The timestamp of when the error was encountered.
-        "$ref": "./DateTime.yml"
+        $ref: "./DateTime.yml"

--- a/components/schemas/accounts/Account.yml
+++ b/components/schemas/accounts/Account.yml
@@ -10,7 +10,7 @@ required:
   - events
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"
   name:
     type: object
     description: The first and last name associated with the Account.
@@ -40,7 +40,7 @@ properties:
         description: If true, the email has been verified and the Account is active.
       added:
         description: The date the email was added to the Account
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
   two_factor_auth:
     description: Two factor auth verification information.
     oneOf:
@@ -56,7 +56,7 @@ properties:
     description: Indicates whether or not Cycle employees have authorization to log in to this Account in a support capacity.
     type: boolean
   state:
-    "$ref": "./AccountState.yml"
+    $ref: "./AccountState.yml"
   events:
     title: AccountEvents
     type: object
@@ -69,13 +69,13 @@ properties:
     properties:
       created:
         description: The timestamp of when the image was created.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       updated:
         description: The timestamp of when the image was updated.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       deleted:
         description: The timestamp of when the image was deleted.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       last_login:
         description: The timestamp of when the Account was last accessed.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"

--- a/components/schemas/accounts/AccountEmployeeLogin.yml
+++ b/components/schemas/accounts/AccountEmployeeLogin.yml
@@ -2,7 +2,7 @@ title: AccountEmployeeLogin
 type: object
 description: A login event where the authentication mechanism was an employee login.
 allOf:
-  - "$ref": "./AccountLogin.yml"
+  - $ref: "./AccountLogin.yml"
   - type: object
     properties:
       type:

--- a/components/schemas/accounts/AccountInfo.yml
+++ b/components/schemas/accounts/AccountInfo.yml
@@ -6,7 +6,7 @@ required:
   - ip
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"
   ip:
     type: string
     description: The IP of the request used during login.

--- a/components/schemas/accounts/AccountLogin.yml
+++ b/components/schemas/accounts/AccountLogin.yml
@@ -9,12 +9,12 @@ required:
   - success
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"
   account:
-    "$ref": "./AccountInfo.yml"
+    $ref: "./AccountInfo.yml"
   time:
     description: A timestamp of the time the login occurred.
-    "$ref": "../DateTime.yml"
+    $ref: "../DateTime.yml"
   type:
     type: string
     description: The type of login mechanism used.

--- a/components/schemas/accounts/AccountState.yml
+++ b/components/schemas/accounts/AccountState.yml
@@ -14,4 +14,4 @@ allOf:
           - purging
           - deleting
           - deleted
-  - "$ref": "../State.yml"
+  - $ref: "../State.yml"

--- a/components/schemas/announcements/Announcement.yml
+++ b/components/schemas/announcements/Announcement.yml
@@ -12,7 +12,7 @@ required:
   - state
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"
   title:
     type: string
     description: A description of the event being announced.
@@ -22,7 +22,7 @@ properties:
   updates:
     type: array
     items:
-      "$ref": "./AnnouncementUpdate.yml"
+      $ref: "./AnnouncementUpdate.yml"
   affected_integrations:
     type: array
     items:
@@ -32,7 +32,7 @@ properties:
     items:
       type: string
   creator:
-    "$ref": "../creators/CreatorScope.yml"
+    $ref: "../creators/CreatorScope.yml"
   state:
     allOf:
       - required:
@@ -45,7 +45,7 @@ properties:
               - live
               - deleting
               - deleted
-      - "$ref": "../State.yml"
+      - $ref: "../State.yml"
   priority:
     type: string
     description: The priority or severity of the announcement.
@@ -67,13 +67,13 @@ properties:
     properties:
       created:
         description: The timestamp of when the announcement was created.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       updated:
         description: The timestamp of when the announcement was updated.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       deleted:
         description: The timestamp of when the announcement was deleted.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       resolved:
         description: The timestamp of when the announcement was resolved.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"

--- a/components/schemas/announcements/AnnouncementState.yml
+++ b/components/schemas/announcements/AnnouncementState.yml
@@ -9,4 +9,4 @@ allOf:
         enum:
           - live
           - deleted
-  - "$ref": "../State.yml"
+  - $ref: "../State.yml"

--- a/components/schemas/announcements/AnnouncementUpdate.yml
+++ b/components/schemas/announcements/AnnouncementUpdate.yml
@@ -8,12 +8,12 @@ required:
   - time
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"
   message:
     type: string
     description: The text describing the update to the announcement.
   creator:
-    "$ref": "../creators/CreatorScope.yml"
+    $ref: "../creators/CreatorScope.yml"
   time:
-    "$ref": "../DateTime.yml"
+    $ref: "../DateTime.yml"
     description: A timestamp of when the update took place.

--- a/components/schemas/billing/BillingOrder.yml
+++ b/components/schemas/billing/BillingOrder.yml
@@ -14,25 +14,25 @@ required:
   - state
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"
   hub_id:
-    "$ref": "../HubID.yml"
+    $ref: "../HubID.yml"
   creator:
-    "$ref": "../creators/CreatorScope.yml"
+    $ref: "../creators/CreatorScope.yml"
   promo_code_id:
     type:
       - string
       - "null"
     description: An ID associated with a promo code used with the order.
   term:
-    "$ref": "./Term.yml"
+    $ref: "./Term.yml"
   approved:
     type: boolean
     description: A boolean where true represents the order is approved to be paid by the user.
   items:
     type: array
     items:
-      "$ref": "./orders/OrderItem.yml"
+      $ref: "./orders/OrderItem.yml"
   total_price:
     type: integer
     description: 1/10th of a cent.
@@ -48,16 +48,16 @@ properties:
     properties:
       created:
         description: The timestamp of when the billing order was created.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       updated:
         description: The timestamp of when the billing order was updated.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       deleted:
         description: The timestamp of when the billing order was deleted.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       expires:
         description: The timestamp of when the billing order expires.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
   state:
     allOf:
       - required:
@@ -71,4 +71,4 @@ properties:
               - processed
               - deleting
               - deleted
-      - "$ref": "../State.yml"
+      - $ref: "../State.yml"

--- a/components/schemas/billing/BillingService.yml
+++ b/components/schemas/billing/BillingService.yml
@@ -15,24 +15,24 @@ required:
   - state
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"
   hub_id:
-    "$ref": "../HubID.yml"
+    $ref: "../HubID.yml"
   creator:
-    "$ref": "../creators/CreatorScope.yml"
+    $ref: "../creators/CreatorScope.yml"
   title:
     type: string
     description: Billing service title.
   order:
-    "$ref": "./orders/Order.yml"
+    $ref: "./orders/Order.yml"
   item:
-    "$ref": "./ServiceItem.yml"
+    $ref: "./ServiceItem.yml"
   discount:
-    "$ref": "./discounts/AssociatedDiscount.yml"
+    $ref: "./discounts/AssociatedDiscount.yml"
   price:
-    "$ref": "./BillingAmount.yml"
+    $ref: "./BillingAmount.yml"
   term:
-    "$ref": "./Term.yml"
+    $ref: "./Term.yml"
   events:
     title: BillingServiceEvents
     type: object
@@ -45,15 +45,15 @@ properties:
     properties:
       created:
         description: The timestamp of when the billing service was created.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       updated:
         description: The timestamp of when the billing service was updated.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       deleted:
         description: The timestamp of when the billing service was deleted.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       last_billed:
         description: The timestamp of when the billing service was last billed.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
   state:
-    "$ref": "./BillingServiceState.yml"
+    $ref: "./BillingServiceState.yml"

--- a/components/schemas/billing/BillingServiceState.yml
+++ b/components/schemas/billing/BillingServiceState.yml
@@ -8,4 +8,4 @@ allOf:
         type: string
         enum:
           - active
-  - "$ref": "../State.yml"
+  - $ref: "../State.yml"

--- a/components/schemas/billing/BillingSummary.yml
+++ b/components/schemas/billing/BillingSummary.yml
@@ -22,7 +22,7 @@ properties:
       - tier
       - support
   term:
-    "$ref": "./Term.yml"
+    $ref: "./Term.yml"
   price:
     type: number
     description: 1/10th of a cent (mills).

--- a/components/schemas/billing/PromoCode.yml
+++ b/components/schemas/billing/PromoCode.yml
@@ -11,14 +11,14 @@ properties:
     type: string
     description: The promo "code".
   expires:
-    "$ref": "../DateTime.yml"
+    $ref: "../DateTime.yml"
   credit:
     description: The amount of credit the promo code offers.
     oneOf:
       - type: object
         properties:
           amount:
-            "$ref": "./BillingAmount.yml"
+            $ref: "./BillingAmount.yml"
           expires:
             type: object
             required:
@@ -47,4 +47,4 @@ properties:
             enum:
               - live
               - deleted
-      - "$ref": "../State.yml"
+      - $ref: "../State.yml"

--- a/components/schemas/billing/ServiceItem.yml
+++ b/components/schemas/billing/ServiceItem.yml
@@ -11,7 +11,7 @@ properties:
       - price
     properties:
       id:
-        "$ref": "../ID.yml"
+        $ref: "../ID.yml"
       name:
         type: string
         description: The support contract name.
@@ -27,9 +27,9 @@ properties:
       - price
     properties:
       id:
-        "$ref": "../ID.yml"
+        $ref: "../ID.yml"
       name:
         type: string
         description: The support contract name.
       price:
-        "$ref": "./BillingAmount.yml"
+        $ref: "./BillingAmount.yml"

--- a/components/schemas/billing/ServiceOrder.yml
+++ b/components/schemas/billing/ServiceOrder.yml
@@ -6,7 +6,7 @@ required:
   - item_id
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"
   item_id:
     type: string
     description: The ID of the billing item.

--- a/components/schemas/billing/SupportPlan.yml
+++ b/components/schemas/billing/SupportPlan.yml
@@ -13,12 +13,12 @@ properties:
     type: string
     description: The name of the support plan.
   price:
-    "$ref": "./BillingAmount.yml"
+    $ref: "./BillingAmount.yml"
   description:
     type: string
     description: Information about the billing support plan that describes the plan.
   features:
-    "$ref": "./SupportPlanFeatures.yml"
+    $ref: "./SupportPlanFeatures.yml"
   contract:
     type: boolean
     description: A boolean where true represents the plan is a long term contract, not just month to month.

--- a/components/schemas/billing/Term.yml
+++ b/components/schemas/billing/Term.yml
@@ -8,10 +8,10 @@ required:
 properties:
   start:
     description: A timestamp describing the start of a billing term.
-    "$ref": "../DateTime.yml"
+    $ref: "../DateTime.yml"
   end:
     description: A timestamp describing the end of a billing term.
-    "$ref": "../DateTime.yml"
+    $ref: "../DateTime.yml"
   renew:
     description: The term renewal period.
     oneOf:

--- a/components/schemas/billing/credits/Credit.yml
+++ b/components/schemas/billing/credits/Credit.yml
@@ -14,9 +14,9 @@ required:
   - state
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   description:
     type: string
     description: Some extra information about the billing credit.
@@ -36,7 +36,7 @@ properties:
         properties:
           date:
             description: A timestamp of when the billing credit expires.
-            "$ref": "../../DateTime.yml"
+            $ref: "../../DateTime.yml"
       - type: "null"
   events:
     title: BillingCreditEvents
@@ -49,13 +49,13 @@ properties:
     properties:
       created:
         description: The timestamp of when the billing order was created.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       updated:
         description: The timestamp of when the billing order was updated.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       deleted:
         description: The timestamp of when the billing order was deleted.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
   state:
     allOf:
       - required:
@@ -68,4 +68,4 @@ properties:
               - new
               - live
               - expired
-      - "$ref": "../../State.yml"
+      - $ref: "../../State.yml"

--- a/components/schemas/billing/discounts/AssociatedDiscount.yml
+++ b/components/schemas/billing/discounts/AssociatedDiscount.yml
@@ -7,9 +7,9 @@ required:
   - expires
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   amount:
-    "$ref": "../BillingAmount.yml"
+    $ref: "../BillingAmount.yml"
   expires:
     description: A timestamp of when the discount expires.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"

--- a/components/schemas/billing/invoices/Invoice.yml
+++ b/components/schemas/billing/invoices/Invoice.yml
@@ -12,9 +12,9 @@ required:
   - events
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   billing_contact:
     oneOf:
       - $ref: ../../hubs/HubBillingContact.yml
@@ -27,34 +27,34 @@ properties:
       - array
       - "null"
     items:
-      "$ref": "../BillingSummary.yml"
+      $ref: "../BillingSummary.yml"
   payments:
     type:
       - array
       - "null"
     items:
-      "$ref": "./Payment.yml"
+      $ref: "./Payment.yml"
   credits:
     type:
       - array
       - "null"
     items:
-      "$ref": "./InvoiceCredit.yml"
+      $ref: "./InvoiceCredit.yml"
   late_fees:
     type:
       - array
       - "null"
     items:
-      "$ref": "./LateFee.yml"
+      $ref: "./LateFee.yml"
   charges:
     type: integer
     description: The amount in charges generated through the licesnse agreement + overages for the billing period covered by the invoice.
   due:
     description: A timestamp of when the invoice is due to be paid.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"
   overdue:
     description: A timestamp of when the invoice is overdue.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"
   failed_payment_attempts:
     type: integer
     description: The number of failed payment attempts for the invoice.
@@ -73,29 +73,29 @@ properties:
     properties:
       created:
         description: The timestamp of when the billing order was created.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       updated:
         description: The timestamp of when the billing order was updated.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       deleted:
         description: The timestamp of when the billing order was deleted.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       billed:
         description: The timestamp of when the billing order billed.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       paid:
         description: The timestamp of when the billing order paid.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       payment_attempt:
         description: The timestamp of when the billing order payment was attempted.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       credited:
         description: The timestamp of when the billing order credited.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       voided:
         description: The timestamp of when the billing order voided.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
   state:
-    "$ref": "./InvoiceState.yml"
+    $ref: "./InvoiceState.yml"
   meta:
-    "$ref": "./InvoiceMeta.yml"
+    $ref: "./InvoiceMeta.yml"

--- a/components/schemas/billing/invoices/InvoiceCredit.yml
+++ b/components/schemas/billing/invoices/InvoiceCredit.yml
@@ -9,7 +9,7 @@ required:
   - amount
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   associated_credit:
     type: object
     description: Credit associated with an invoice.
@@ -18,13 +18,13 @@ properties:
       - amount
     properties:
       id:
-        "$ref": "../../ID.yml"
+        $ref: "../../ID.yml"
       amount:
         type: integer
         description: The amount of the credit.
   time:
     description: A timestamp for when the invoice credit was created.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"
   description:
     type: string
     description: A description of the invoice credit.

--- a/components/schemas/billing/invoices/InvoiceIncludes.yml
+++ b/components/schemas/billing/invoices/InvoiceIncludes.yml
@@ -3,4 +3,4 @@ description: All includable resources linkable to the given invoice.
 type: object
 properties:
   hubs:
-    "$ref": "../../includes/HubIncludes.yml"
+    $ref: "../../includes/IncludedHubs.yml"

--- a/components/schemas/billing/invoices/InvoiceState.yml
+++ b/components/schemas/billing/invoices/InvoiceState.yml
@@ -21,4 +21,4 @@ allOf:
           - "voiding"
           - "voided"
           - "uncollectible"
-  - "$ref": "../../State.yml"
+  - $ref: "../../State.yml"

--- a/components/schemas/billing/invoices/LateFee.yml
+++ b/components/schemas/billing/invoices/LateFee.yml
@@ -8,10 +8,10 @@ required:
   - amount
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   time:
     description: A timestamp of when the late fee was created.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"
   description:
     type: string
     description: A description of the late fee.

--- a/components/schemas/billing/invoices/Payment.yml
+++ b/components/schemas/billing/invoices/Payment.yml
@@ -12,10 +12,10 @@ required:
   - gateway
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   time:
     description: A timestamp for the payment.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"
   description:
     type: string
     description: Some information about the payment.
@@ -28,11 +28,11 @@ properties:
   refunds:
     type: array
     items:
-      "$ref": "./Refund.yml"
+      $ref: "./Refund.yml"
   method_id:
     type: string
     description: The ID associated with the billing method used.
   result:
-    "$ref": "./PaymentResult.yml"
+    $ref: "./PaymentResult.yml"
   gateway:
-    "$ref": "./PaymentGateway.yml"
+    $ref: "./PaymentGateway.yml"

--- a/components/schemas/billing/invoices/Refund.yml
+++ b/components/schemas/billing/invoices/Refund.yml
@@ -9,10 +9,10 @@ required:
   - gateway
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   time:
     description: A timestamp for the payment.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"
   description:
     type: string
     description: Some information about the payment refund.
@@ -20,4 +20,4 @@ properties:
     type: integer
     description: 1/10th of a cent.
   gateway:
-    "$ref": "./PaymentGateway.yml"
+    $ref: "./PaymentGateway.yml"

--- a/components/schemas/billing/methods/Method.yml
+++ b/components/schemas/billing/methods/Method.yml
@@ -12,7 +12,7 @@ required:
   - events
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   name:
     type: string
     description: A name for the billing method.
@@ -40,7 +40,7 @@ properties:
               - pending-verification
               - deleting
               - deleted
-      - "$ref": "../../State.yml"
+      - $ref: "../../State.yml"
   events:
     title: CreditCardEvents
     type: object
@@ -52,10 +52,10 @@ properties:
     properties:
       created:
         description: The timestamp of when the credit card was created.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       updated:
         description: The timestamp of when the credit card was updated.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       deleted:
         description: The timestamp of when the credit card was deleted.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"

--- a/components/schemas/billing/orders/Order.yml
+++ b/components/schemas/billing/orders/Order.yml
@@ -15,19 +15,19 @@ properties:
   hub_id:
     type: string
   creator:
-    "$ref": "../../common/UserScope.yml"
+    $ref: "../../common/UserScope.yml"
   promo_code_id:
     type:
       - string
       - "null"
   term:
-    "$ref": "../Term.yml"
+    $ref: "../Term.yml"
   approved:
     type: boolean
   items:
     type: array
     items:
-      "$ref": "./OrderItem.yml"
+      $ref: "./OrderItem.yml"
   total_price:
     type: number
   events:
@@ -39,6 +39,6 @@ properties:
     properties:
       expires:
         description: The timestamp of when the order expires.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
   state:
-    "$ref": "./OrderState.yml"
+    $ref: "./OrderState.yml"

--- a/components/schemas/billing/orders/OrderItem.yml
+++ b/components/schemas/billing/orders/OrderItem.yml
@@ -11,11 +11,11 @@ properties:
   id:
     type: string
   service:
-    "$ref": "../ServiceItem.yml"
+    $ref: "../ServiceItem.yml"
   description:
     type: string
   price:
-    "$ref": "../BillingAmount.yml"
+    $ref: "../BillingAmount.yml"
   discount:
     type: object
     required:
@@ -26,8 +26,8 @@ properties:
       id:
         type: string
       amount:
-        "$ref": "../BillingAmount.yml"
+        $ref: "../BillingAmount.yml"
       expires:
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
   net_price:
     type: number

--- a/components/schemas/billing/orders/OrderState.yml
+++ b/components/schemas/billing/orders/OrderState.yml
@@ -11,4 +11,4 @@ allOf:
           - processed
           - deleting
           - deleted
-  - "$ref": "../../State.yml"
+  - $ref: "../../State.yml"

--- a/components/schemas/billing/plans/TierPlan.yml
+++ b/components/schemas/billing/plans/TierPlan.yml
@@ -83,11 +83,11 @@ properties:
       - integer
       - "null"
   ram:
-    "$ref": "../BillingRam.yml"
+    $ref: "../BillingRam.yml"
   image_storage:
-    "$ref": "../BillingImageStorage.yml"
+    $ref: "../BillingImageStorage.yml"
   builds:
-    "$ref": "../BillingBuilds.yml"
+    $ref: "../BillingBuilds.yml"
   hidden:
     type: boolean
   hubs:

--- a/components/schemas/changelog/ChangelogEntry.yml
+++ b/components/schemas/changelog/ChangelogEntry.yml
@@ -74,13 +74,13 @@ properties:
     properties:
       created:
         description: The timestamp of when the changelog entry was created.
-        "$ref": ../../../components/schemas/DateTime.yml
+        $ref: ../../../components/schemas/DateTime.yml
       updated:
         description: The timestamp of when the changelog entry was updated.
-        "$ref": ../../../components/schemas/DateTime.yml
+        $ref: ../../../components/schemas/DateTime.yml
       deleted:
         description: The timestamp of when the changelog entry was deleted.
-        "$ref": ../../../components/schemas/DateTime.yml
+        $ref: ../../../components/schemas/DateTime.yml
   email_events:
     type: array
     items:
@@ -104,7 +104,7 @@ properties:
         sender:
           $ref: ../../../components/schemas/common/UserScope.yml
   creator:
-    "$ref": "../../../components/schemas/creators/CreatorScope.yml"
+    $ref: "../../../components/schemas/creators/CreatorScope.yml"
   changes:
     type: array
     items:

--- a/components/schemas/common/UserScope.yml
+++ b/components/schemas/common/UserScope.yml
@@ -5,7 +5,7 @@ required:
   - type
   - id
 properties:
-  type: 
+  type:
     type: string
     description: The type of user that created the resource.
     enum:
@@ -17,4 +17,4 @@ properties:
       - api-key
       - visitor
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"

--- a/components/schemas/containers/ContainerIncludes.yml
+++ b/components/schemas/containers/ContainerIncludes.yml
@@ -3,17 +3,16 @@ description: All includable resources linkable to the given container.
 type: object
 properties:
   creators:
-    "$ref": "../includes/CreatorInclude.yml"
+    $ref: "../includes/CreatorIncludes.yml"
   images:
-    "$ref": "../includes/ImagesIncludes.yml"
+    $ref: "../includes/IncludedImages.yml"
   stack_builds:
-    "$ref": "../includes/StackBuildIncludes.yml"
+    $ref: "../includes/IncludedStackBuilds.yml"
   stacks:
-    "$ref": "../includes/StackIncludes.yml"
+    $ref: "../includes/IncludedStacks.yml"
   "stacks:identifiers":
-    $ref: ../includes/IdentifierIncludes.yml
+    $ref: ../includes/IncludedIdentifiers.yml
   environments:
-    "$ref": "../includes/EnvironmentIncludes.yml"
+    $ref: "../includes/IncludedEnvironments.yml"
   "environments:identifiers":
-    $ref: ../includes/IdentifierIncludes.yml
-  
+    $ref: ../includes/IncludedIdentifiers.yml

--- a/components/schemas/containers/ContainerState.yml
+++ b/components/schemas/containers/ContainerState.yml
@@ -29,4 +29,4 @@ allOf:
           - deleting
           - deleted
 
-  - "$ref": "../State.yml"
+  - $ref: "../State.yml"

--- a/components/schemas/containers/ContainersMeta.yml
+++ b/components/schemas/containers/ContainersMeta.yml
@@ -3,7 +3,7 @@ type: object
 description: A list of meta fields that can be applied to a container.
 properties:
   instances_count:
-    "$ref": "../StateCountSummary.yml"
+    $ref: "../StateCountSummary.yml"
   domains:
     type:
       - array
@@ -18,9 +18,9 @@ properties:
           type: string
           description: The fully qualified domain name.
         record:
-          "$ref": "../dns/records/DnsRecord.yml"
+          $ref: "../dns/records/DnsRecord.yml"
   ips:
     description: An array of IP resources.
     type: array
     items:
-      "$ref": "../infrastructure/ips/Ip.yml"
+      $ref: "../infrastructure/ips/Ip.yml"

--- a/components/schemas/containers/backups/ContainerBackup.yml
+++ b/components/schemas/containers/backups/ContainerBackup.yml
@@ -11,9 +11,9 @@ required:
   - events
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   container_id:
     type: string
     description: The ID of the given container.
@@ -21,9 +21,9 @@ properties:
     type: string
     description: The ID of the instance the backup belongs to.
   target:
-    "$ref": "ContainerBackupTarget.yml"
+    $ref: "ContainerBackupTarget.yml"
   state:
-    "$ref": "ContainerBackupState.yml"
+    $ref: "ContainerBackupState.yml"
   events:
     title: BackupEvents
     type: object
@@ -35,10 +35,10 @@ properties:
     properties:
       created:
         description: The timestamp of when the backup was created.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       updated:
         description: The timestamp of when the backup was updated.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       deleted:
         description: The timestamp of when the backup was deleted.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"

--- a/components/schemas/containers/backups/ContainerBackupIncludes.yml
+++ b/components/schemas/containers/backups/ContainerBackupIncludes.yml
@@ -3,4 +3,4 @@ description: All includable resources linkable to the given Zone.
 type: object
 properties:
   integrations:
-    "$ref": "../../includes/IntegrationsIncludes.yml"
+    $ref: "../../includes/IncludedIntegrations.yml"

--- a/components/schemas/containers/backups/ContainerBackupLogs.yml
+++ b/components/schemas/containers/backups/ContainerBackupLogs.yml
@@ -12,7 +12,7 @@ required:
   - events
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   container_id:
     type: string
     description: An identifier for the container.
@@ -23,7 +23,7 @@ properties:
     type: string
     description: An identifier for the backup.
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   type:
     type: string
     description: The type of the backup log.
@@ -70,10 +70,10 @@ properties:
     properties:
       created:
         description: The timestamp of when the backup log was created.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       updated:
         description: The timestamp of when the backup log was updated.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       deleted:
         description: The timestamp of when the backup log was deleted.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"

--- a/components/schemas/containers/backups/ContainerBackupState.yml
+++ b/components/schemas/containers/backups/ContainerBackupState.yml
@@ -11,4 +11,4 @@ allOf:
           - live
           - deleting
           - deleted
-  - "$ref": "../../State.yml"
+  - $ref: "../../State.yml"

--- a/components/schemas/containers/instances/InstanceIncludes.yml
+++ b/components/schemas/containers/instances/InstanceIncludes.yml
@@ -3,20 +3,20 @@ description: A resource associated with an instance.
 type: object
 properties:
   creators:
-    "$ref": "../../includes/CreatorInclude.yml"
+    $ref: ../../includes/CreatorIncludes.yml
   servers:
-    "$ref": "../../includes/ServersIncludes.yml"
+    $ref: ../../includes/IncludedServers.yml
   locations:
-    "$ref": "../../includes/LocationsIncludes.yml"
+    $ref: ../../includes/IncludedLocations.yml
   integrations:
-    "$ref": "../../includes/IntegrationsIncludes.yml"
+    $ref: ../../includes/IncludedIntegrations.yml
   "integrations:identifiers":
-    $ref: ../../includes/IdentifierIncludes.yml
+    $ref: ../../includes/IncludedIdentifiers.yml
   containers:
-    "$ref": "../../includes/ContainersIncludes.yml"
+    $ref: ../..//includes/IncludedContainers.yml
   "containers:identifiers":
-    $ref: ../../includes/IdentifierIncludes.yml
+    $ref: ../../includes/IncludedIdentifiers.yml
   environments:
-    "$ref": "../../includes/EnvironmentIncludes.yml"
+    $ref: ../../includes/IncludedEnvironments.yml
   "environments:identifiers":
-    $ref: ../../includes/IdentifierIncludes.yml
+    $ref: ../../includes/IncludedIdentifiers.yml

--- a/components/schemas/containers/instances/InstanceResourceSnapshot.yml
+++ b/components/schemas/containers/instances/InstanceResourceSnapshot.yml
@@ -1,34 +1,34 @@
-title: InstanceResourceSnapshot 
-type: object 
-description: A snapshot of instance telemetry. 
-required: 
-  - time 
-  - cpu 
-  - memory 
-  - processes 
-properties: 
-  time: 
-    description: A timestamp for when the snapshot was taken. 
-    "$ref": "../../DateTime.yml" 
-  hub_id: 
-    "$ref": "../../HubID.yml"
-  container_id: 
-    type: string 
-    description: The ID of the container the instance was created from. 
-  instance_id: 
-    type: string 
-    description: The ID of the instance. 
-  environment_id: 
-    type: string 
-    description: The ID of the environment this instnace is in. 
-  cpu: 
-    "$ref": "./snapshots/CPUSnapshot.yml" 
-  memory: 
-    "$ref": "./snapshots/MemorySnapshot.yml" 
-  processes:  
-    "$ref": "./snapshots/ProcessesSnapshot.yml" 
-  hugetlb: 
-    type: object 
-    description: Records of HugeTLB resource data. 
-    additionalProperties: 
-      "$ref": "./snapshots/HugeTLB.yml" 
+title: InstanceResourceSnapshot
+type: object
+description: A snapshot of instance telemetry.
+required:
+  - time
+  - cpu
+  - memory
+  - processes
+properties:
+  time:
+    description: A timestamp for when the snapshot was taken.
+    $ref: "../../DateTime.yml"
+  hub_id:
+    $ref: "../../HubID.yml"
+  container_id:
+    type: string
+    description: The ID of the container the instance was created from.
+  instance_id:
+    type: string
+    description: The ID of the instance.
+  environment_id:
+    type: string
+    description: The ID of the environment this instnace is in.
+  cpu:
+    $ref: "./snapshots/CPUSnapshot.yml"
+  memory:
+    $ref: "./snapshots/MemorySnapshot.yml"
+  processes:
+    $ref: "./snapshots/ProcessesSnapshot.yml"
+  hugetlb:
+    type: object
+    description: Records of HugeTLB resource data.
+    additionalProperties:
+      $ref: "./snapshots/HugeTLB.yml"

--- a/components/schemas/containers/instances/SSHToken.yml
+++ b/components/schemas/containers/instances/SSHToken.yml
@@ -11,7 +11,7 @@ required:
   - valid
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   instance_id:
     type: string
     description: The ID of the instance being connected to.
@@ -19,9 +19,9 @@ properties:
     type: string
     description: The ID of the container from which the instance was created.
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   creator:
-    "$ref": "../../creators/CreatorScope.yml"
+    $ref: "../../creators/CreatorScope.yml"
   events:
     title: SSHTokenEvents
     type: object
@@ -33,13 +33,13 @@ properties:
     properties:
       created:
         description: The timestamp of when the SSH token was created.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       used:
         description: The timestamp of when the SSH token was used.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       expires:
         description: The timestamp of when the SSH token expires.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
   valid:
     type: boolean
     description: A boolean where true represents the token as being a valid token to be used for connection.

--- a/components/schemas/containers/instances/returns/InstanceTelemetryReport.yml
+++ b/components/schemas/containers/instances/returns/InstanceTelemetryReport.yml
@@ -6,9 +6,9 @@ required:
   - snapshots
 properties:
   request:
-    "$ref": "../snapshots/TelemetryReportRequest.yml"
+    $ref: "../snapshots/TelemetryReportRequest.yml"
   snapshots:
     description: An array of telemetry snapshots.
     type: array
     items:
-      "$ref": "../snapshots/ResourceSnapshot.yml"
+      $ref: "../snapshots/ResourceSnapshot.yml"

--- a/components/schemas/containers/instances/snapshots/MemorySnapshot.yml
+++ b/components/schemas/containers/instances/snapshots/MemorySnapshot.yml
@@ -1,20 +1,19 @@
-title: InstanceTelemetryMemorySnapshot 
-type: object 
-description: A snapshot of memory usage statistics. 
-properties: 
-  cache: 
-    type: number 
-    description: The number of bytes of page cache memory being used by this instance. 
-  usage: 
-    description: The memory usage data. 
-    "$ref": "./MemoryData.yml"
-  swap_usage: 
-    description: Memory swap usage data. 
-    "$ref": "./MemoryData.yml"
-  kernel_usage: 
-    description: Kernal memory usage. 
-    "$ref": "./MemoryData.yml"
-  kernel_tcp_usage: 
-    description: Kernel TCP buffer usage. 
-    "$ref": "./MemoryData.yml"
-  
+title: InstanceTelemetryMemorySnapshot
+type: object
+description: A snapshot of memory usage statistics.
+properties:
+  cache:
+    type: number
+    description: The number of bytes of page cache memory being used by this instance.
+  usage:
+    description: The memory usage data.
+    $ref: "./MemoryData.yml"
+  swap_usage:
+    description: Memory swap usage data.
+    $ref: "./MemoryData.yml"
+  kernel_usage:
+    description: Kernal memory usage.
+    $ref: "./MemoryData.yml"
+  kernel_tcp_usage:
+    description: Kernel TCP buffer usage.
+    $ref: "./MemoryData.yml"

--- a/components/schemas/containers/instances/snapshots/TelemetryReportRequest.yml
+++ b/components/schemas/containers/instances/snapshots/TelemetryReportRequest.yml
@@ -11,7 +11,7 @@ properties:
     description: The ID of the instance this telemetry reporting pertains to.
   start:
     description: A timestamp of when the snapshot began.
-    "$ref": "../../../DateTime.yml"
+    $ref: "../../../DateTime.yml"
   end:
     description: A timestamp of when the snapshot ended.
-    "$ref": "../../../DateTime.yml"
+    $ref: "../../../DateTime.yml"

--- a/components/schemas/containers/summaries/VolumeSummary.yml
+++ b/components/schemas/containers/summaries/VolumeSummary.yml
@@ -7,12 +7,12 @@ required:
   - config
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   hash:
     type: string
     description: A unique hash for the given volume.
   config:
-    "$ref": "../config/ContainerVolume.yml"
+    $ref: "../config/ContainerVolume.yml"
   external:
     description: The ID of external volume, if applicable.
     oneOf:

--- a/components/schemas/containers/task/ContainerReconfigureAction.yml
+++ b/components/schemas/containers/task/ContainerReconfigureAction.yml
@@ -10,4 +10,4 @@ properties:
       - reconfigure
     description: The action to take.
   contents:
-    "$ref": "../config/Config.yml"
+    $ref: "../config/Config.yml"

--- a/components/schemas/creators/ApiKeyCreator.yml
+++ b/components/schemas/creators/ApiKeyCreator.yml
@@ -54,6 +54,6 @@ properties:
               - live
               - deleting
               - deleted
-      - "$ref": "../State.yml"
+      - $ref: "../State.yml"
   events:
     $ref: "../Events.yml"

--- a/components/schemas/dns/DnsZone.yml
+++ b/components/schemas/dns/DnsZone.yml
@@ -11,11 +11,11 @@ required:
   - events
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"
   hub_id:
-    "$ref": "../HubID.yml"
+    $ref: "../HubID.yml"
   creator:
-    "$ref": "../creators/CreatorScope.yml"
+    $ref: "../creators/CreatorScope.yml"
   origin:
     type: string
     description: The origin for the given DNS zone.
@@ -27,7 +27,7 @@ properties:
       - $ref: ../common/ACL.yml
       - type: "null"
   state:
-    "$ref": "./DnsZoneState.yml"
+    $ref: "./DnsZoneState.yml"
   events:
     title: ZoneEvents
     type: object
@@ -41,16 +41,16 @@ properties:
     properties:
       created:
         description: The timestamp of when the DNS zone was created.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       updated:
         description: The timestamp of when the DNS zone was updated.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       deleted:
         description: The timestamp of when the DNS zone was deleted.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       last_verification:
         description: The timestamp of when the DNS zone was last_verification.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       verified:
         description: The timestamp of when the DNS zone was verified.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"

--- a/components/schemas/dns/DnsZoneIncludes.yml
+++ b/components/schemas/dns/DnsZoneIncludes.yml
@@ -3,4 +3,4 @@ description: All includable resources linkable to the given Zone.
 type: object
 properties:
   creators:
-    "$ref": "../includes/CreatorInclude.yml"
+    $ref: "../includes/CreatorIncludes.yml"

--- a/components/schemas/dns/DnsZoneState.yml
+++ b/components/schemas/dns/DnsZoneState.yml
@@ -14,4 +14,4 @@ allOf:
           - disabled
           - deleting
           - deleted
-  - "$ref": "../State.yml"
+  - $ref: "../State.yml"

--- a/components/schemas/dns/records/DnsRecordState.yml
+++ b/components/schemas/dns/records/DnsRecordState.yml
@@ -11,4 +11,4 @@ allOf:
           - live
           - deleting
           - deleted
-  - "$ref": "../../State.yml"
+  - $ref: "../../State.yml"

--- a/components/schemas/dns/tls/Attempt.yml
+++ b/components/schemas/dns/tls/Attempt.yml
@@ -1,29 +1,28 @@
-title: DNSTLSAttempt 
-type: object 
-description: A DNS TLS certificate generation attempt resource. 
-required: 
-  - id 
-  - hub_id 
-  - domains 
-  - time 
-  - success 
-properties: 
-  id: 
-    "$ref": "../../ID.yml" 
-  hub_id: 
-    "$ref": "../../HubID.yml" 
-  domains: 
-    description: A list of domains associated with the attempt. 
-    type: array 
-    items: 
-      type: string 
-  time: 
-    description: A timestamp for when the attempt took place. 
-    "$ref": "../../DateTime.yml" 
-  success: 
-    description: A boolean where true means the attept was successful at creating the TLS certificate. 
-    type: boolean 
-  error: 
-    type: string 
-    description: If success is false this property will be populated with an error. 
-  
+title: DNSTLSAttempt
+type: object
+description: A DNS TLS certificate generation attempt resource.
+required:
+  - id
+  - hub_id
+  - domains
+  - time
+  - success
+properties:
+  id:
+    $ref: "../../ID.yml"
+  hub_id:
+    $ref: "../../HubID.yml"
+  domains:
+    description: A list of domains associated with the attempt.
+    type: array
+    items:
+      type: string
+  time:
+    description: A timestamp for when the attempt took place.
+    $ref: "../../DateTime.yml"
+  success:
+    description: A boolean where true means the attept was successful at creating the TLS certificate.
+    type: boolean
+  error:
+    type: string
+    description: If success is false this property will be populated with an error.

--- a/components/schemas/dns/tls/TlsCertificate.yml
+++ b/components/schemas/dns/tls/TlsCertificate.yml
@@ -46,16 +46,16 @@ properties:
     properties:
       created:
         description: The timestamp of when the TLS certificate was created.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       updated:
         description: The timestamp of when the TLS certificate was updated.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       deleted:
         description: The timestamp of when the TLS certificate was deleted.
-        "$ref": ../../DateTime.yml
+        $ref: ../../DateTime.yml
       generated:
         description: The timestamp of when the TLS certificate was generated.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
 required:
   - id
   - user_supplied

--- a/components/schemas/environments/EnvironmentState.yml
+++ b/components/schemas/environments/EnvironmentState.yml
@@ -13,4 +13,4 @@ allOf:
           - cloning
           - deleting
           - deleted
-  - "$ref": "../State.yml"
+  - $ref: "../State.yml"

--- a/components/schemas/environments/PrivateNetwork.yml
+++ b/components/schemas/environments/PrivateNetwork.yml
@@ -16,7 +16,7 @@ properties:
   ipv6:
     allOf:
       - description: The IPv6 interface.
-      - "$ref": "./IPNet.yml"
+      - $ref: "./IPNet.yml"
   legacy:
     anyOf:
       - $ref: "./LegacyNetwork.yml"

--- a/components/schemas/environments/returns/VPNLogin.yml
+++ b/components/schemas/environments/returns/VPNLogin.yml
@@ -10,7 +10,7 @@ required:
   - success
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   username:
     type: string
     description: The username used when logging in.
@@ -22,7 +22,7 @@ properties:
     description: The IP address of the machine the user has logged in from.
   time:
     description: The timestamp for when the login occured.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"
   success:
     type: boolean
     description: A boolean where true means the login attempt was successful.

--- a/components/schemas/environments/returns/VPNUsers.yml
+++ b/components/schemas/environments/returns/VPNUsers.yml
@@ -11,17 +11,17 @@ required:
   - events
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   username:
     type: string
     description: The username for the login.
   creator:
-    "$ref": "../../creators/CreatorScope.yml"
+    $ref: "../../creators/CreatorScope.yml"
   last_login:
     description: A timestamp of the last time the user logged into the VPN.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   environment_id:
     type: string
     description: An identifier for the environment the VPN service is associated with.
@@ -36,10 +36,10 @@ properties:
     properties:
       created:
         description: The timestamp of when the VPN user was created.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       updated:
         description: The timestamp of when the VPN user was updated.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       deleted:
         description: The timestamp of when the VPN user was deleted.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"

--- a/components/schemas/hubs/ApiKeyState.yml
+++ b/components/schemas/hubs/ApiKeyState.yml
@@ -1,16 +1,16 @@
-title: ApiKeyState 
-allOf: 
-  - required: 
-      - current 
-    properties: 
-      current: 
-        description: The current state of the API key. 
-        type: string 
-        enum: 
-          - new 
-          - configuring 
-          - live 
-          - inactive 
-          - deleting 
-          - deleted 
-  - "$ref": "../State.yml" 
+title: ApiKeyState
+allOf:
+  - required:
+      - current
+    properties:
+      current:
+        description: The current state of the API key.
+        type: string
+        enum:
+          - new
+          - configuring
+          - live
+          - inactive
+          - deleting
+          - deleted
+  - $ref: "../State.yml"

--- a/components/schemas/hubs/HubBillingProfile.yml
+++ b/components/schemas/hubs/HubBillingProfile.yml
@@ -8,7 +8,7 @@ required:
   - emails
 properties:
   term:
-    "$ref": "../billing/Term.yml"
+    $ref: "../billing/Term.yml"
   allow_prepaid:
     type: boolean
     description: A boolean where true represents this account being approved to use a prepaid card for billing transactions.

--- a/components/schemas/hubs/HubMembership.yml
+++ b/components/schemas/hubs/HubMembership.yml
@@ -12,12 +12,12 @@ required:
   - prefereneces
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"
   account_id:
     type: string
     description: An ID for the account associated with the given membership.
   hub_id:
-    "$ref": "../HubID.yml"
+    $ref: "../HubID.yml"
   events:
     title: MembershipEvents
     type: object
@@ -27,16 +27,16 @@ properties:
     properties:
       created:
         description: The timestamp of when the membership was created.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       updated:
         description: The timestamp of when the membership was updated.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       deleted:
         description: The timestamp of when the membership was deleted.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       joined:
         description: The timestamp of when the membership was accepted.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
   role_id:
     definition: The ID of the Role assigned to this Hub Membership.
     $ref: ../ID.yml

--- a/components/schemas/hubs/HubMeta.yml
+++ b/components/schemas/hubs/HubMeta.yml
@@ -3,4 +3,4 @@ type: object
 description: A list of meta fields that can be applied to a hub.
 properties:
   membership:
-    "$ref": "./HubMembership.yml"
+    $ref: "./HubMembership.yml"

--- a/components/schemas/hubs/HubState.yml
+++ b/components/schemas/hubs/HubState.yml
@@ -1,16 +1,16 @@
-title: HubState 
-allOf: 
-  - required: 
-      - current 
-    properties: 
-      current: 
-        description: The current state of the hub. 
-        type: string 
-        enum: 
-          - new 
-          - configuring 
-          - live 
-          - inactive 
-          - deleting 
-          - deleted 
-  - "$ref": "../State.yml" 
+title: HubState
+allOf:
+  - required:
+      - current
+    properties:
+      current:
+        description: The current state of the hub.
+        type: string
+        enum:
+          - new
+          - configuring
+          - live
+          - inactive
+          - deleting
+          - deleted
+  - $ref: "../State.yml"

--- a/components/schemas/hubs/Invitation.yml
+++ b/components/schemas/hubs/Invitation.yml
@@ -1,26 +1,26 @@
-title: HubMembershipInvitation 
-type: object 
-description: Information about a hub membership invitation. 
-required: 
-  - sender 
-  - recipient 
-  - events 
-properties: 
-  sender: 
-    type: object 
-    description: Information about the origin account of the invitation. 
-    required: 
-      - id 
-      - type 
-    properties: 
-      id: 
-        "$ref": "../ID.yml" 
-      type: 
-        type: string 
-        description: The account type. 
-  recipient: 
-    type: string 
-    description: The email address for the invitations recipient. 
+title: HubMembershipInvitation
+type: object
+description: Information about a hub membership invitation.
+required:
+  - sender
+  - recipient
+  - events
+properties:
+  sender:
+    type: object
+    description: Information about the origin account of the invitation.
+    required:
+      - id
+      - type
+    properties:
+      id:
+        $ref: "../ID.yml"
+      type:
+        type: string
+        description: The account type.
+  recipient:
+    type: string
+    description: The email address for the invitations recipient.
   events:
     title: InvitationEvents
     type: object
@@ -30,24 +30,24 @@ properties:
       - updated
       - deleted
       - accepted
-      - declined 
-      - revoked 
+      - declined
+      - revoked
     properties:
       created:
         description: The timestamp of when the invitation was created.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       updated:
         description: The timestamp of when the invitation was updated.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       deleted:
         description: The timestamp of when the invitation was deleted.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       accepted:
         description: The timestamp of when the invitation was accepted.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       declined:
         description: The timestamp of when the invitation was declined.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       revoked:
         description: The timestamp of when the invitation was revoked.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"

--- a/components/schemas/hubs/MembershipState.yml
+++ b/components/schemas/hubs/MembershipState.yml
@@ -12,4 +12,4 @@ allOf:
           - declined
           - revoked
           - deleted
-  - "$ref": "../State.yml"
+  - $ref: "../State.yml"

--- a/components/schemas/hubs/activity/Activity.yml
+++ b/components/schemas/hubs/activity/Activity.yml
@@ -17,9 +17,9 @@ required:
   - time
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   user:
     type: object
     description: Userscope
@@ -85,7 +85,7 @@ properties:
           - type
         properties:
           id:
-            "$ref": "../../ID.yml"
+            $ref: "../../ID.yml"
           type:
             type: string
             description: The type of component.
@@ -393,4 +393,4 @@ properties:
 
   time:
     description: A timestamp for when the activity took place.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"

--- a/components/schemas/hubs/activity/ActivityIncludes.yml
+++ b/components/schemas/hubs/activity/ActivityIncludes.yml
@@ -4,6 +4,6 @@ type: object
 properties:
   users:
     # TODO - I think this should be User Include in this case.  Just need to check cross deps
-    "$ref": "../../includes/CreatorInclude.yml"
+    $ref: "../../includes/CreatorIncludes.yml"
   components:
-    "$ref": "../../includes/ComponentsIncludes.yml"
+    $ref: "../../includes/ComponentsIncludes.yml"

--- a/components/schemas/hubs/activity/Change.yml
+++ b/components/schemas/hubs/activity/Change.yml
@@ -8,6 +8,6 @@ properties:
     type: string
     description: A description of the resource that was changed.
   before:
-    "$ref": "./Detail.yml"
+    $ref: "./Detail.yml"
   after:
-    "$ref": "./Detail.yml"
+    $ref: "./Detail.yml"

--- a/components/schemas/hubs/activity/Detail.yml
+++ b/components/schemas/hubs/activity/Detail.yml
@@ -3,7 +3,7 @@ type: object
 description: Details about a given event that is part of an activity.
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   number:
     type: integer
     description: A number describing the amount of the resource that exists.

--- a/components/schemas/images/BuildLog.yml
+++ b/components/schemas/images/BuildLog.yml
@@ -1,23 +1,23 @@
 title: ImageBuildLog
-description: A build log for a given image. 
-type: object 
-required:   
-  - id 
-  - image_id 
-  - hub_id 
-  - log 
-  - events 
-properties: 
-  id: 
-    "$ref": "../ID.yml" 
-  hub_id: 
-    "$ref": "../HubID.yml" 
-  image_id: 
-    type: string 
-    description: The ID of the image the build log pertains to. 
-  log:  
-    type: string 
-    description: The log itself. 
+description: A build log for a given image.
+type: object
+required:
+  - id
+  - image_id
+  - hub_id
+  - log
+  - events
+properties:
+  id:
+    $ref: "../ID.yml"
+  hub_id:
+    $ref: "../HubID.yml"
+  image_id:
+    type: string
+    description: The ID of the image the build log pertains to.
+  log:
+    type: string
+    description: The log itself.
   events:
     title: BuildLogEvents
     type: object
@@ -29,10 +29,10 @@ properties:
     properties:
       created:
         description: The timestamp of when the build log was created.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       updated:
         description: The timestamp of when the build log was updated.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       deleted:
         description: The timestamp of when the build log was deleted.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"

--- a/components/schemas/images/Image.yml
+++ b/components/schemas/images/Image.yml
@@ -13,9 +13,9 @@ required:
   - events
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"
   hub_id:
-    "$ref": "../HubID.yml"
+    $ref: "../HubID.yml"
   name:
     type: string
     description: A user defined name for the image.
@@ -174,7 +174,7 @@ properties:
       - $ref: sources/StackImageSourceType.yml
       - $ref: sources/BucketImageSourceType.yml
   creator:
-    "$ref": "../creators/CreatorScope.yml"
+    $ref: "../creators/CreatorScope.yml"
   factory:
     oneOf:
       - type: object
@@ -195,7 +195,7 @@ properties:
             description: A date timestamp for when the node acknowledged the image import job.
       - type: "null"
   state:
-    "$ref": "./ImageState.yml"
+    $ref: "./ImageState.yml"
   events:
     title: ImageEvents
     type: object
@@ -207,12 +207,12 @@ properties:
     properties:
       created:
         description: The timestamp of when the image was created.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       updated:
         description: The timestamp of when the image was updated.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       deleted:
         description: The timestamp of when the image was deleted.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
   meta:
-    "$ref": "./ImageMeta.yml"
+    $ref: "./ImageMeta.yml"

--- a/components/schemas/images/ImageIncludes.yml
+++ b/components/schemas/images/ImageIncludes.yml
@@ -3,18 +3,18 @@ description: All includable resources linkable to the given image.
 type: object
 properties:
   creators:
-    "$ref": "../includes/CreatorInclude.yml"
+    $ref: "../includes/CreatorIncludes.yml"
   stack_builds:
-    "$ref": "../includes/StackBuildIncludes.yml"
+    $ref: "../includes/IncludedStackBuilds.yml"
   stacks:
-    "$ref": "../includes/StackIncludes.yml"
+    $ref: "../includes/IncludedStacks.yml"
   "stacks:identifiers":
-    $ref: ../includes/IdentifierIncludes.yml
+    $ref: ../includes/IncludedIdentifiers.yml
   sources:
-    "$ref": "../includes/ImageSourceIncludes.yml"
+    $ref: "../includes/IncludedImageSources.yml"
   "sources:identifiers":
-    $ref: ../includes/IdentifierIncludes.yml
+    $ref: ../includes/IncludedIdentifiers.yml
   integrations:
-    "$ref": "../includes/IntegrationsIncludes.yml"
+    $ref: "../includes/IncludedIntegrations.yml"
   "integrations:identifiers":
-    $ref: ../includes/IdentifierIncludes.yml
+    $ref: ../includes/IncludedIdentifiers.yml

--- a/components/schemas/images/ImageMeta.yml
+++ b/components/schemas/images/ImageMeta.yml
@@ -3,4 +3,4 @@ type: object
 description: A list of meta fields that can be applied to the image.
 properties:
   containers_count:
-    "$ref": "../StateCountSummary.yml"
+    $ref: "../StateCountSummary.yml"

--- a/components/schemas/images/ImageState.yml
+++ b/components/schemas/images/ImageState.yml
@@ -16,4 +16,4 @@ allOf:
           - live
           - deleting
           - deleted
-  - "$ref": "../State.yml"
+  - $ref: "../State.yml"

--- a/components/schemas/images/sources/ImageSource.yml
+++ b/components/schemas/images/sources/ImageSource.yml
@@ -13,14 +13,14 @@ required:
   - creator
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   identifier:
     $ref: ../../Identifier.yml
     description: A human readable slugged identifier for this image source.
   type:
     $ref: ImageSourceType.yml
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   name:
     type: string
     description: A name for the image source resource.
@@ -40,13 +40,13 @@ properties:
             description: The ID or Identifier of the Integration used to do the build.
       - type: "null"
   creator:
-    "$ref": "../../creators/CreatorScope.yml"
+    $ref: "../../creators/CreatorScope.yml"
   acl:
     anyOf:
       - $ref: ../../common/ACL.yml
       - type: "null"
   state:
-    "$ref": "./ImageSourceState.yml"
+    $ref: "./ImageSourceState.yml"
   events:
     title: ImageSourceEvents
     type: object
@@ -58,12 +58,12 @@ properties:
     properties:
       created:
         description: The timestamp of when the image source was created.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       updated:
         description: The timestamp of when the image source was updated.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       deleted:
         description: The timestamp of when the image source was deleted.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
   meta:
     $ref: "./ImageSourceMeta.yml"

--- a/components/schemas/images/sources/ImageSourceState.yml
+++ b/components/schemas/images/sources/ImageSourceState.yml
@@ -10,4 +10,4 @@ allOf:
           - live
           - deleting
           - deleted
-  - "$ref": "../../State.yml"
+  - $ref: "../../State.yml"

--- a/components/schemas/images/sources/SourceIncludes.yml
+++ b/components/schemas/images/sources/SourceIncludes.yml
@@ -1,10 +1,10 @@
-title: SourceIncludes 
-description: A resource associate with an image source. 
-type: object 
-properties: 
-  creators: 
-    "$ref": "../../includes/CreatorInclude.yml"
+title: SourceIncludes
+description: A resource associate with an image source.
+type: object
+properties:
+  creators:
+    $ref: "../../includes/CreatorIncludes.yml"
   integrations:
-    "$ref": "../../includes/IntegrationsIncludes.yml"
+    $ref: "../../includes/IncludedIntegrations.yml"
   "integrations:identifiers":
-    $ref: ../../includes/IdentifierIncludes.yml
+    $ref: ../../includes/IncludedIdentifiers.yml

--- a/components/schemas/includes/ClusterIncludes.yml
+++ b/components/schemas/includes/ClusterIncludes.yml
@@ -1,5 +1,0 @@
-title: ClusterIncludes
-description: A resource associated with a cluster.
-type: object
-additionalProperties:
-  "$ref": "../infrastructure/clusters/Cluster.yml"

--- a/components/schemas/includes/ContainersIncludes.yml
+++ b/components/schemas/includes/ContainersIncludes.yml
@@ -1,5 +1,0 @@
-title: ContainersIncludes
-type: object
-description: A resource that is associated with a container.
-additionalProperties:
-  "$ref": "../containers/Container.yml"

--- a/components/schemas/includes/CreatorIncludes.yml
+++ b/components/schemas/includes/CreatorIncludes.yml
@@ -1,5 +1,4 @@
----
-title: CreatorInclude
+title: CreatorIncludes
 description: An identity that created a resource.
 type: object
 properties:

--- a/components/schemas/includes/EnvironmentIncludes.yml
+++ b/components/schemas/includes/EnvironmentIncludes.yml
@@ -1,5 +1,0 @@
-title: EnvironmentInclude
-description: An identity that is associated with an environment.
-type: object
-additionalProperties:
-  "$ref": "../environments/Environment.yml"

--- a/components/schemas/includes/HubIncludes.yml
+++ b/components/schemas/includes/HubIncludes.yml
@@ -1,5 +1,0 @@
-title: HubIncludes
-type: object
-description: A resource that is associated with a hub.
-additionalProperties:
-  "$ref": "../hubs/Hub.yml"

--- a/components/schemas/includes/ImageSourceIncludes.yml
+++ b/components/schemas/includes/ImageSourceIncludes.yml
@@ -1,5 +1,0 @@
-title: ImageSourceIncludes
-description: A resource associated with an image source.
-type: object
-additionalProperties:
-  "$ref": "../images/sources/ImageSource.yml"

--- a/components/schemas/includes/ImagesIncludes.yml
+++ b/components/schemas/includes/ImagesIncludes.yml
@@ -1,5 +1,0 @@
-title: ImageIncludes
-description: A resource associated with an image.
-type: object
-additionalProperties:
-  "$ref": "../images/Image.yml"

--- a/components/schemas/includes/IncludedClusters.yml
+++ b/components/schemas/includes/IncludedClusters.yml
@@ -1,0 +1,6 @@
+title: IncludedClusters
+description: |
+  A map of clusters, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+type: object
+additionalProperties:
+  $ref: ../infrastructure/clusters/Cluster.yml

--- a/components/schemas/includes/IncludedContainers.yml
+++ b/components/schemas/includes/IncludedContainers.yml
@@ -1,0 +1,6 @@
+title: IncludedContainers
+type: object
+description: |
+  A map of containers, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+additionalProperties:
+  $ref: ../containers/Container.yml

--- a/components/schemas/includes/IncludedEnvironments.yml
+++ b/components/schemas/includes/IncludedEnvironments.yml
@@ -1,0 +1,6 @@
+title: IncludedEnvironments
+description: |
+  A map of environments, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+type: object
+additionalProperties:
+  $ref: ../environments/Environment.yml

--- a/components/schemas/includes/IncludedHubs.yml
+++ b/components/schemas/includes/IncludedHubs.yml
@@ -1,0 +1,6 @@
+title: IncludedHubs
+type: object
+description: |
+  A map of hubs, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+additionalProperties:
+  $ref: ../hubs/Hub.yml

--- a/components/schemas/includes/IncludedIdentifiers.yml
+++ b/components/schemas/includes/IncludedIdentifiers.yml
@@ -1,4 +1,4 @@
-title: IdentifierIncludes
+title: IncludedIdentifiers
 type: object
 description: A map of identifiers to an array of resource IDs that are associated with it. All IDs point to the same type of resource.
 additionalProperties:

--- a/components/schemas/includes/IncludedImageSources.yml
+++ b/components/schemas/includes/IncludedImageSources.yml
@@ -1,0 +1,6 @@
+title: IncludedImageSources
+description: |
+  A map of image sources, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+type: object
+additionalProperties:
+  $ref: ../images/sources/ImageSource.yml

--- a/components/schemas/includes/IncludedImages.yml
+++ b/components/schemas/includes/IncludedImages.yml
@@ -1,0 +1,6 @@
+title: IncludedImages
+description: |
+  A map of images, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+type: object
+additionalProperties:
+  $ref: ../images/Image.yml

--- a/components/schemas/includes/IncludedIntegrations.yml
+++ b/components/schemas/includes/IncludedIntegrations.yml
@@ -1,0 +1,6 @@
+title: IncludedIntegrations
+description: |
+  A map of integrations, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+type: object
+additionalProperties:
+  $ref: ../hubs/integrations/Integration.yml

--- a/components/schemas/includes/IncludedLocations.yml
+++ b/components/schemas/includes/IncludedLocations.yml
@@ -1,0 +1,6 @@
+title: IncludedLocations
+description: |
+  A map of locations, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+type: object
+additionalProperties:
+  $ref: ../infrastructure/providers/ProviderLocation.yml

--- a/components/schemas/includes/IncludedNodes.yml
+++ b/components/schemas/includes/IncludedNodes.yml
@@ -1,0 +1,6 @@
+title: IncludedNodes
+description: |
+  A map of nodes, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+type: object
+additionalProperties:
+  $ref: ../../../../../cycle-openapi/components/schemas/infrastructure/nodes/Node.yml

--- a/components/schemas/includes/IncludedPromoCodes.yml
+++ b/components/schemas/includes/IncludedPromoCodes.yml
@@ -1,0 +1,6 @@
+title: IncludedPromoCodes
+type: object
+description: |
+  A map of promo codes, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+additionalProperties:
+  $ref: ../billing/PromoCode.yml

--- a/components/schemas/includes/IncludedProviderServerModels.yml
+++ b/components/schemas/includes/IncludedProviderServerModels.yml
@@ -1,0 +1,6 @@
+title: IncludedProviderServerModels
+description: |
+  A map of provider server models, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+type: object
+additionalProperties:
+  $ref: ../infrastructure/providers/models/ProviderServerModel.yml

--- a/components/schemas/includes/IncludedServers.yml
+++ b/components/schemas/includes/IncludedServers.yml
@@ -1,0 +1,6 @@
+title: IncludedServers
+description: |
+  A map of servers, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+type: object
+additionalProperties:
+  $ref: ../infrastructure/servers/Server.yml

--- a/components/schemas/includes/IncludedStackBuilds.yml
+++ b/components/schemas/includes/IncludedStackBuilds.yml
@@ -1,0 +1,6 @@
+title: IncludedStackBuilds
+description: |
+  A map of stack builds, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+type: object
+additionalProperties:
+  $ref: ../stacks/builds/StackBuild.yml

--- a/components/schemas/includes/IncludedStacks.yml
+++ b/components/schemas/includes/IncludedStacks.yml
@@ -1,0 +1,6 @@
+title: IncludedStacks
+description: |
+  A map of stacks, keyed by ID, included on endpoints that support it when passing the matching includes query parameter.
+type: object
+additionalProperties:
+  $ref: ../stacks/Stack.yml

--- a/components/schemas/includes/IntegrationsIncludes.yml
+++ b/components/schemas/includes/IntegrationsIncludes.yml
@@ -1,5 +1,0 @@
-title: IntegrationsIncludes
-description: A resource that is associated with an integration.
-type: object
-additionalProperties:
-  $ref: ../hubs/integrations/Integration.yml

--- a/components/schemas/includes/LocationsIncludes.yml
+++ b/components/schemas/includes/LocationsIncludes.yml
@@ -1,5 +1,0 @@
-title: LocationIncludes
-description: A resource that is associated with a provider location.
-type: object
-additionalProperties:
-  "$ref": "../infrastructure/providers/ProviderLocation.yml"

--- a/components/schemas/includes/PromoCodeInclude.yml
+++ b/components/schemas/includes/PromoCodeInclude.yml
@@ -1,5 +1,0 @@
-title: PromoCodeIncludes
-type: object
-description: A resource that is associated with a promo code.
-additionalProperties:
-  "$ref": "../billing/PromoCode.yml"

--- a/components/schemas/includes/ProviderServerModelsIncludes.yml
+++ b/components/schemas/includes/ProviderServerModelsIncludes.yml
@@ -1,5 +1,0 @@
-title: ProviderServerModelsIncludes
-description: A resource associated with a server models.
-type: object
-additionalProperties:
-  $ref: ../infrastructure/providers/models/ProviderServerModel.yml

--- a/components/schemas/includes/ServersIncludes.yml
+++ b/components/schemas/includes/ServersIncludes.yml
@@ -1,5 +1,0 @@
-title: ServerIncludes
-description: A resource that is associated with a server.
-type: object
-additionalProperties:
-  "$ref": "../infrastructure/servers/Server.yml"

--- a/components/schemas/includes/StackBuildIncludes.yml
+++ b/components/schemas/includes/StackBuildIncludes.yml
@@ -1,5 +1,0 @@
-title: StackBuildInclude
-description: A resource that is associated with a stack build.
-type: object
-additionalProperties:
-  "$ref": "../stacks/builds/StackBuild.yml"

--- a/components/schemas/includes/StackIncludes.yml
+++ b/components/schemas/includes/StackIncludes.yml
@@ -1,5 +1,0 @@
-title: StackIncludes
-description: A resource associated with a stack.
-type: object
-additionalProperties:
-  "$ref": "../stacks/Stack.yml"

--- a/components/schemas/infrastructure/auto-scale/groups/AutoScaleGroupIncludes.yml
+++ b/components/schemas/infrastructure/auto-scale/groups/AutoScaleGroupIncludes.yml
@@ -3,8 +3,8 @@ description: All includable resource linkable to the given auto-scale group.
 type: object
 properties:
   integrations:
-    "$ref": "../../../includes/IntegrationsIncludes.yml"
+    $ref: "../../../includes/IncludedIntegrations.yml"
   models:
-    "$ref": "../../../includes/ProviderServerModelsIncludes.yml"
+    $ref: "../../../includes/IncludedProviderServerModels.yml"
   locations:
-    "$ref": "../../../includes/LocationsIncludes.yml"
+    $ref: "../../../includes/IncludedLocations.yml"

--- a/components/schemas/infrastructure/clusters/ClusterState.yml
+++ b/components/schemas/infrastructure/clusters/ClusterState.yml
@@ -11,4 +11,4 @@ allOf:
           - live
           - deleting
           - deleted
-  - "$ref": "../../State.yml"
+  - $ref: "../../State.yml"

--- a/components/schemas/infrastructure/external-volumes/ExternalVolumeState.yml
+++ b/components/schemas/infrastructure/external-volumes/ExternalVolumeState.yml
@@ -13,4 +13,4 @@ allOf:
           - live
           - deleting
           - deleted
-  - "$ref": "../../State.yml"
+  - $ref: "../../State.yml"

--- a/components/schemas/infrastructure/ips/IpPool.yml
+++ b/components/schemas/infrastructure/ips/IpPool.yml
@@ -14,9 +14,9 @@ required:
   - state
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   server_id:
     type: string
     description: An ID associated with a server resource.
@@ -30,7 +30,7 @@ properties:
       - ipv4
       - ipv6
   provider:
-    "$ref": "./IpPoolProvider.yml"
+    $ref: "./IpPoolProvider.yml"
   floating:
     type: boolean
     description: A boolean where true represents the pool as a floating IP pool.
@@ -69,4 +69,4 @@ properties:
           - $ref: ../../Cidr.yml
           - type: "null"
   state:
-    "$ref": "./IpPoolState.yml"
+    $ref: "./IpPoolState.yml"

--- a/components/schemas/infrastructure/ips/IpPoolIncludes.yml
+++ b/components/schemas/infrastructure/ips/IpPoolIncludes.yml
@@ -3,10 +3,10 @@ type: object
 description: Resources associated with an IP Pool.
 properties:
   creators:
-    "$ref": "../../includes/CreatorInclude.yml"
+    $ref: "../../includes/CreatorIncludes.yml"
   servers:
-    "$ref": "../../includes/ServersIncludes.yml"
+    $ref: "../../includes/IncludedServers.yml"
   integrations:
-    "$ref": "../../includes/IntegrationsIncludes.yml"
+    $ref: "../../includes/IncludedIntegrations.yml"
   locations:
-    "$ref": "../../includes/LocationsIncludes.yml"
+    $ref: "../../includes/IncludedLocations.yml"

--- a/components/schemas/infrastructure/ips/IpPoolState.yml
+++ b/components/schemas/infrastructure/ips/IpPoolState.yml
@@ -10,4 +10,4 @@ allOf:
           - live
           - releasing
           - released
-  - "$ref": "../../State.yml"
+  - $ref: "../../State.yml"

--- a/components/schemas/infrastructure/san/luns/SanLunState.yml
+++ b/components/schemas/infrastructure/san/luns/SanLunState.yml
@@ -10,4 +10,4 @@ allOf:
           - live
           - deleting
           - deleted
-  - "$ref": "../../../State.yml"
+  - $ref: "../../../State.yml"

--- a/components/schemas/infrastructure/san/targets/SanTargetState.yml
+++ b/components/schemas/infrastructure/san/targets/SanTargetState.yml
@@ -11,4 +11,4 @@ allOf:
           - live
           - deleting
           - deleted
-  - "$ref": "../../../State.yml"
+  - $ref: "../../../State.yml"

--- a/components/schemas/infrastructure/servers/NodeState.yml
+++ b/components/schemas/infrastructure/servers/NodeState.yml
@@ -28,4 +28,4 @@ allOf:
               - decommissioned
               - deleted
           - type: "null"
-  - "$ref": "../../State.yml"
+  - $ref: "../../State.yml"

--- a/components/schemas/infrastructure/servers/ServerIncludes.yml
+++ b/components/schemas/infrastructure/servers/ServerIncludes.yml
@@ -3,12 +3,10 @@ type: object
 description: A resource associated with a server.
 properties:
   locations:
-    "$ref": "../../includes/LocationsIncludes.yml"
+    $ref: ../../includes/IncludedLocations.yml
   clusters:
-    type: object
-    additionalProperties:
-      "$ref": ../clusters/Cluster.yml
+    $ref: ../../includes/IncludedClusters.yml
   models:
-    "$ref": "../../includes/ProviderServerModelsIncludes.yml"
+    $ref: ../../includes/IncludedProviderServerModels.yml
   integrations:
-    "$ref": "../../includes/IntegrationsIncludes.yml"
+    $ref: ../../includes/IncludedIntegrations.yml

--- a/components/schemas/infrastructure/servers/ServerMeta.yml
+++ b/components/schemas/infrastructure/servers/ServerMeta.yml
@@ -16,16 +16,16 @@ properties:
     properties:
       last_checkin:
         description: The last time this server checked in with the platform.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       drivers:
         description: An array a drivers associated with the given server.
         type: array
         items:
           type: string
       state:
-        "$ref": "./NodeState.yml"
+        $ref: "./NodeState.yml"
       stats:
-        "$ref": "../stats/NodeMetaStats.yml"
+        $ref: "../stats/NodeMetaStats.yml"
       healthy:
         type: boolean
         description: A boolean where true means the platform is reporting the server as healthy.
@@ -33,7 +33,7 @@ properties:
         type: boolean
         description: A boolean where true means the server is online and reachable by the platform.
   instances_count:
-    "$ref": "../../StateCountSummary.yml"
+    $ref: "../../StateCountSummary.yml"
   allocations:
     type: object
     required:

--- a/components/schemas/infrastructure/servers/ServerState.yml
+++ b/components/schemas/infrastructure/servers/ServerState.yml
@@ -14,4 +14,4 @@ allOf:
           - live
           - deleting
           - deleted
-  - "$ref": "../../State.yml"
+  - $ref: "../../State.yml"

--- a/components/schemas/infrastructure/servers/UsageDatum.yml
+++ b/components/schemas/infrastructure/servers/UsageDatum.yml
@@ -1,19 +1,17 @@
-title: ServerUsageDatum 
-type: object 
-description: Server usage data. 
-required: 
-  - time 
-  - nodes 
-  - memory_gb 
-properties: 
-  time: 
-    description: A timestamp for when the usage data was collected. 
-    "$ref": "../../DateTime.yml" 
-  nodes: 
-    type: integer 
-    description: The number of nodes the data is pulled from. 
-  memory_gb: 
-    type: integer 
-    description: A number in GB representing memory. 
-
-    
+title: ServerUsageDatum
+type: object
+description: Server usage data.
+required:
+  - time
+  - nodes
+  - memory_gb
+properties:
+  time:
+    description: A timestamp for when the usage data was collected.
+    $ref: "../../DateTime.yml"
+  nodes:
+    type: integer
+    description: The number of nodes the data is pulled from.
+  memory_gb:
+    type: integer
+    description: A number in GB representing memory.

--- a/components/schemas/infrastructure/servers/requestBodies/CreateServerRequest.yml
+++ b/components/schemas/infrastructure/servers/requestBodies/CreateServerRequest.yml
@@ -40,7 +40,7 @@ content:
                   description: Advanced server options.
                   properties:
                     features:
-                      "$ref": "../ServerFeatures.yml"
+                      $ref: "../ServerFeatures.yml"
                     provision_options:
                       description: Advanced options to apply to the provisioning of a server.
                       oneOf:

--- a/components/schemas/infrastructure/stats/ServerStatsTelemetry.yml
+++ b/components/schemas/infrastructure/stats/ServerStatsTelemetry.yml
@@ -10,13 +10,13 @@ required:
 properties:
   time:
     description: The timestamp for when the telemetery data was collected.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"
   cpu_usage:
     $ref: ./ServerStatsCpuUsageTelemetry.yml
   load:
-    "$ref": "./ServerStatsLoad.yml"
+    $ref: "./ServerStatsLoad.yml"
   ram:
-    "$ref": "./ServerStatsRamTelemetry.yml"
+    $ref: "./ServerStatsRamTelemetry.yml"
   storage_base:
     type: object
     description: Telemetry data for the base volume of a given server.

--- a/components/schemas/infrastructure/summary/InfrastructureSummary.yml
+++ b/components/schemas/infrastructure/summary/InfrastructureSummary.yml
@@ -9,7 +9,7 @@ required:
   - servers
 properties:
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   servers:
     type: number
     description: The number of servers on the cluster

--- a/components/schemas/jobs/Job.yml
+++ b/components/schemas/jobs/Job.yml
@@ -16,9 +16,9 @@ required:
   - state
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"
   hub_id:
-    "$ref": "../HubID.yml"
+    $ref: "../HubID.yml"
   queue:
     type: string
     description: A dash separated string showing the environment_id where the job is taking place.
@@ -36,24 +36,24 @@ properties:
     properties:
       queued:
         description: The timestamp of when the job was queued.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       completed:
         description: The timestamp of when the job was completed.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       started:
         description: The timestamp of when the job was started.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
   schedule:
     description: A timestamp of when the job was scheduled.
-    "$ref": "../DateTime.yml"
+    $ref: "../DateTime.yml"
   tasks:
     description: An array of job tasks.
     type: array
     items:
-      "$ref": ./JobTask.yml
+      $ref: ./JobTask.yml
   expires:
     description: A timestamp for when the job expires.
-    "$ref": "../DateTime.yml"
+    $ref: "../DateTime.yml"
   hash:
     type: string
     description: A combination of the individual task details and job details.
@@ -61,6 +61,6 @@ properties:
     type: boolean
     description: A boolean where true represents the job is set to prevent duplicates of itself quickly after creation.
   creator:
-    "$ref": "../creators/CreatorScope.yml"
+    $ref: "../creators/CreatorScope.yml"
   state:
-    "$ref": "./JobState.yml"
+    $ref: "./JobState.yml"

--- a/components/schemas/jobs/JobIncludes.yml
+++ b/components/schemas/jobs/JobIncludes.yml
@@ -2,4 +2,4 @@ title: JobIncludes
 type: object
 properties:
   creators:
-    $ref: ../includes/CreatorInclude.yml
+    $ref: ../includes/CreatorIncludes.yml

--- a/components/schemas/jobs/TaskStep.yml
+++ b/components/schemas/jobs/TaskStep.yml
@@ -1,22 +1,21 @@
-title: TaskStep 
-type: object 
-description: A step for a given job task. 
-required: 
+title: TaskStep
+type: object
+description: A step for a given job task.
+required:
   - caption
   - description
-  - started 
-  - completed 
-properties: 
-  caption: 
-    type: string 
-    description: A short description of the step. 
-  description: 
-    type: string 
-    description: A more verbose description. 
-  started: 
-    description: A timestamp for when the step started. 
-    "$ref": "../DateTime.yml"
-  completed: 
-    description: A timestamp for when the step completed. 
-    "$ref": "../DateTime.yml"
-  
+  - started
+  - completed
+properties:
+  caption:
+    type: string
+    description: A short description of the step.
+  description:
+    type: string
+    description: A more verbose description.
+  started:
+    description: A timestamp for when the step started.
+    $ref: "../DateTime.yml"
+  completed:
+    description: A timestamp for when the step completed.
+    $ref: "../DateTime.yml"

--- a/components/schemas/pipelines/PipelineIncludes.yml
+++ b/components/schemas/pipelines/PipelineIncludes.yml
@@ -3,7 +3,7 @@ description: All includable resources linkable to the given pipeline.
 type: object
 properties:
   creators:
-    "$ref": "../includes/CreatorInclude.yml"
+    $ref: "../includes/CreatorIncludes.yml"
   name:
     type: string
     description: A name value.
@@ -12,11 +12,11 @@ properties:
     description: A record of resources that can be associated with the pipeline.
     additionalProperties:
       oneOf:
-        - "$ref": "../containers/Container.yml"
-        - "$ref": "../environments/Environment.yml"
-        - "$ref": "../stacks/Stack.yml"
-        - "$ref": "../stacks/builds/StackBuild.yml"
-        - "$ref": "../images/Image.yml"
-        - "$ref": "../images/sources/ImageSource.yml"
+        - $ref: "../containers/Container.yml"
+        - $ref: "../environments/Environment.yml"
+        - $ref: "../stacks/Stack.yml"
+        - $ref: "../stacks/builds/StackBuild.yml"
+        - $ref: "../images/Image.yml"
+        - $ref: "../images/sources/ImageSource.yml"
   "components:identifiers":
-    $ref: ../includes/IdentifierIncludes.yml
+    $ref: ../includes/IncludedIdentifiers.yml

--- a/components/schemas/pipelines/PipelineStage.yml
+++ b/components/schemas/pipelines/PipelineStage.yml
@@ -13,7 +13,7 @@ properties:
     type: array
     description: An array of steps for the stage.
     items:
-      "$ref": "./PipelineSteps.yml"
+      $ref: "./PipelineSteps.yml"
   options:
     type: object
     description: Additonal options for the stage.

--- a/components/schemas/pipelines/PipelineState.yml
+++ b/components/schemas/pipelines/PipelineState.yml
@@ -12,4 +12,4 @@ allOf:
           - acquiring
           - deleting
           - deleted
-  - "$ref": "../State.yml"
+  - $ref: "../State.yml"

--- a/components/schemas/pipelines/runs/PipelineRun.yml
+++ b/components/schemas/pipelines/runs/PipelineRun.yml
@@ -11,11 +11,11 @@ required:
   - events
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   creator:
-    "$ref": "../../creators/CreatorScope.yml"
+    $ref: "../../creators/CreatorScope.yml"
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   pipeline_id:
     type: string
     description: The ID for the pipeline this run belongs to.
@@ -53,12 +53,12 @@ properties:
           properties:
             started:
               description: The timestamp of when the pipeline stage was started.
-              "$ref": "../../DateTime.yml"
+              $ref: "../../DateTime.yml"
             finished:
-              description: The timestamp of when the pipeline stage was finished.  
-              "$ref": "../../DateTime.yml"
+              description: The timestamp of when the pipeline stage was finished.
+              $ref: "../../DateTime.yml"
   state:
-    "$ref": "./RunState.yml"
+    $ref: "./RunState.yml"
   events:
     $ref: ./PipelineRunEvents.yml
   variables:

--- a/components/schemas/pipelines/runs/PipelineRunEvents.yml
+++ b/components/schemas/pipelines/runs/PipelineRunEvents.yml
@@ -8,10 +8,10 @@ required:
 properties:
   started:
     description: The timestamp of when the pipeline run was started.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"
   queued:
     description: The timestamp of when the pipeline run was queued.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"
   finished:
     description: The timestamp of when the pipeline run was finished.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"

--- a/components/schemas/pipelines/runs/PipelineRunIncludes.yml
+++ b/components/schemas/pipelines/runs/PipelineRunIncludes.yml
@@ -3,7 +3,7 @@ description: Resources related to a pipeline run, that can be included on suppor
 type: object
 properties:
   creators:
-    $ref: ../../../../components/schemas/includes/CreatorInclude.yml
+    $ref: ../../../../components/schemas/includes/CreatorIncludes.yml
   pipelines:
     $ref: ../../../../components/schemas/includes/IncludedPipelines.yml
   keys:

--- a/components/schemas/pipelines/runs/PipelineRunStep.yml
+++ b/components/schemas/pipelines/runs/PipelineRunStep.yml
@@ -48,10 +48,10 @@ properties:
     properties:
       started:
         description: The timestamp of when the pipeline step was started.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       finished:
         description: The timestamp of when the pipeline step was finished.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
   success:
     type: boolean
   components:

--- a/components/schemas/pipelines/runs/RunState.yml
+++ b/components/schemas/pipelines/runs/RunState.yml
@@ -13,4 +13,4 @@ allOf:
           - complete
           - cancelled
           - deleted
-  - "$ref": "../../State.yml"
+  - $ref: "../../State.yml"

--- a/components/schemas/pipelines/trigger-keys/TriggerKey.yml
+++ b/components/schemas/pipelines/trigger-keys/TriggerKey.yml
@@ -13,7 +13,7 @@ required:
   - ips
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   name:
     type: string
     description: The name of the trigger key.
@@ -21,14 +21,14 @@ properties:
     type: string
     description: The secret used when calling the trigger key programmatically.
   creator:
-    "$ref": "../../creators/CreatorScope.yml"
+    $ref: "../../creators/CreatorScope.yml"
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   pipeline_id:
     type: string
     description: The ID for the pipeline related to this trigger key.
   state:
-    "$ref": "./TriggerKeyState.yml"
+    $ref: "./TriggerKeyState.yml"
   events:
     title: TriggerKeyEvents
     type: object
@@ -40,13 +40,13 @@ properties:
     properties:
       created:
         description: The timestamp of when the trigger key was created.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       updated:
         description: The timestamp of when the trigger key was updated.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       deleted:
         description: The timestamp of when the trigger key was deleted.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
   ips:
     description: An array of ips this trigger key is usable from.
     type: array

--- a/components/schemas/pipelines/trigger-keys/TriggerKeyState.yml
+++ b/components/schemas/pipelines/trigger-keys/TriggerKeyState.yml
@@ -7,7 +7,7 @@ allOf:
         description: The current state of the trigger key.
         type: string
         enum:
-          - live 
-          - deleting 
+          - live
+          - deleting
           - deleted
-  - "$ref": "../../State.yml"
+  - $ref: "../../State.yml"

--- a/components/schemas/scoped-variables/ScopedVariable.yml
+++ b/components/schemas/scoped-variables/ScopedVariable.yml
@@ -14,18 +14,18 @@ required:
   - events
 properties:
   id:
-    "$ref": "../ID.yml"
+    $ref: "../ID.yml"
   creator:
-    "$ref": "../creators/CreatorScope.yml"
+    $ref: "../creators/CreatorScope.yml"
   hub_id:
-    "$ref": "../HubID.yml"
+    $ref: "../HubID.yml"
   environment_id:
     type: string
     description: An identifier used to reference the environment this resource is scoped to.
   identifier:
     $ref: ../Identifier.yml
   scope:
-    "$ref": "./ScopedVariableScope.yml"
+    $ref: "./ScopedVariableScope.yml"
   access:
     $ref: ./ScopedVariableAccess.yml
   source:
@@ -46,7 +46,7 @@ properties:
       - $ref: ../containers/Deployment.yml
       - type: "null"
   state:
-    "$ref": "./ScopedVariableState.yml"
+    $ref: "./ScopedVariableState.yml"
   events:
     title: ScopedVariableEvents
     type: object
@@ -58,10 +58,10 @@ properties:
     properties:
       created:
         description: The timestamp of when the scoped variable was created.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       updated:
         description: The timestamp of when the scoped variable was updated.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"
       deleted:
         description: The timestamp of when the scoped variable was deleted.
-        "$ref": "../DateTime.yml"
+        $ref: "../DateTime.yml"

--- a/components/schemas/scoped-variables/ScopedVariableState.yml
+++ b/components/schemas/scoped-variables/ScopedVariableState.yml
@@ -10,4 +10,4 @@ allOf:
           - live
           - deleting
           - deleted
-  - "$ref": "../State.yml"
+  - $ref: "../State.yml"

--- a/components/schemas/sdn/networks/NetworkIncludes.yml
+++ b/components/schemas/sdn/networks/NetworkIncludes.yml
@@ -3,6 +3,6 @@ description: All includable resource linkable to the given network.
 type: object
 properties:
   creators:
-    "$ref": "../../includes/CreatorInclude.yml"
+    $ref: "../../includes/CreatorIncludes.yml"
   environments:
-    "$ref": "../../includes/EnvironmentIncludes.yml"
+    $ref: "../../includes/IncludedEnvironments.yml"

--- a/components/schemas/search/Component.yml
+++ b/components/schemas/search/Component.yml
@@ -21,7 +21,7 @@ properties:
     description: State of the component
     type: string
   events:
-    "$ref": "../Events.yml"
+    $ref: "../Events.yml"
   context_blobs:
     description: related strings for fuzzy search
     type: array

--- a/components/schemas/search/Index.yml
+++ b/components/schemas/search/Index.yml
@@ -16,43 +16,43 @@ required:
 properties:
   generated:
     description: The timestampof when the index was generated
-    "$ref": "../DateTime.yml"
+    $ref: "../DateTime.yml"
   hub_id:
     description: Id describing the Hub
     type: string
   containers:
     type: object
     additionalProperties:
-      "$ref": "./Component.yml"
+      $ref: "./Component.yml"
   environments:
     type: object
     additionalProperties:
-      "$ref": "./Component.yml"
+      $ref: "./Component.yml"
   image_sources:
     type: object
     additionalProperties:
-      "$ref": "./Component.yml"
+      $ref: "./Component.yml"
   dns_zones:
     type: object
     additionalProperties:
-      "$ref": "./Component.yml"
+      $ref: "./Component.yml"
   stacks:
     type: object
     additionalProperties:
-      "$ref": "./Component.yml"
+      $ref: "./Component.yml"
   servers:
     type: object
     additionalProperties:
-      "$ref": "./Component.yml"
+      $ref: "./Component.yml"
   pipelines:
     type: object
     additionalProperties:
-      "$ref": "./Component.yml"
+      $ref: "./Component.yml"
   virtual_machines:
     type: object
     additionalProperties:
-      "$ref": "./Component.yml"
+      $ref: "./Component.yml"
   instances:
     type: object
     additionalProperties:
-      "$ref": "./Component.yml"
+      $ref: "./Component.yml"

--- a/components/schemas/stacks/StackInclude.yml
+++ b/components/schemas/stacks/StackInclude.yml
@@ -1,6 +1,6 @@
 title: StackIncludes
-description: All includable resources linkable to the given stack. 
-type: object 
-properties: 
+description: All includable resources linkable to the given stack.
+type: object
+properties:
   creators:
-    "$ref": "../includes/CreatorInclude.yml"
+    $ref: "../includes/CreatorIncludes.yml"

--- a/components/schemas/stacks/StackMeta.yml
+++ b/components/schemas/stacks/StackMeta.yml
@@ -3,6 +3,6 @@ type: object
 description: A list of meta fields that can be applied to this stack.
 properties:
   containers_count:
-    "$ref": "../StateCountSummary.yml"
+    $ref: "../StateCountSummary.yml"
   builds_count:
-    "$ref": "../StateCountSummary.yml"
+    $ref: "../StateCountSummary.yml"

--- a/components/schemas/stacks/StackState.yml
+++ b/components/schemas/stacks/StackState.yml
@@ -10,4 +10,4 @@ allOf:
           - live
           - deleting
           - deleted
-  - "$ref": "../State.yml"
+  - $ref: "../State.yml"

--- a/components/schemas/stacks/builds/StackBuildLog.yml
+++ b/components/schemas/stacks/builds/StackBuildLog.yml
@@ -10,9 +10,9 @@ required:
   - events
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   stack_id:
     type: string
     description: The ID of stack the build log pertains to.
@@ -33,10 +33,10 @@ properties:
     properties:
       created:
         description: The timestamp of when the build log was created.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       updated:
         description: The timestamp of when the build log was updated.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       deleted:
         description: The timestamp of when the build log was deleted.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"

--- a/components/schemas/stacks/builds/StackBuildMeta.yml
+++ b/components/schemas/stacks/builds/StackBuildMeta.yml
@@ -3,4 +3,4 @@ type: object
 description: A list of meta fields that can be applied to a stack build.
 properties:
   containers_count:
-    "$ref": "../../StateCountSummary.yml"
+    $ref: "../../StateCountSummary.yml"

--- a/components/schemas/stacks/builds/StackBuildState.yml
+++ b/components/schemas/stacks/builds/StackBuildState.yml
@@ -16,4 +16,4 @@ allOf:
           - deploying
           - deleting
           - deleted
-  - "$ref": "../../State.yml"
+  - $ref: "../../State.yml"

--- a/components/schemas/stacks/builds/StackGitCommit.yml
+++ b/components/schemas/stacks/builds/StackGitCommit.yml
@@ -1,4 +1,4 @@
-title: StackGitCommit 
+title: StackGitCommit
 type: object
 description: Information about the git commit this stack build was created from.
 required:
@@ -15,7 +15,7 @@ properties:
     description: The commit message for the given stack build hash.
   time:
     description: The time the commit was made.
-    "$ref": "../../DateTime.yml"
+    $ref: "../../DateTime.yml"
   author:
     type: object
     description: Inforamtion about the author of the commit.

--- a/components/schemas/stacks/requestBodies/CreateStackRequest.yml
+++ b/components/schemas/stacks/requestBodies/CreateStackRequest.yml
@@ -1,14 +1,14 @@
-description: Parameters for creating a new stack. 
-content: 
+description: Parameters for creating a new stack.
+content:
   application/json:
-    schema: 
-      type: object 
-      required: 
-        - name 
-        - source 
-      properties: 
-        name: 
-          type: string 
-          description: A name for the stack. 
-        source: 
-          "$ref": "../StackSource.yml"   
+    schema:
+      type: object
+      required:
+        - name
+        - source
+      properties:
+        name:
+          type: string
+          description: A name for the stack.
+        source:
+          $ref: "../StackSource.yml"

--- a/components/schemas/stacks/requestBodies/UpdateStackRequest.yml
+++ b/components/schemas/stacks/requestBodies/UpdateStackRequest.yml
@@ -1,11 +1,11 @@
-description: Parameters for updating a stack. 
-content: 
-  application/json: 
-    schema: 
-      type: object 
-      properties: 
-        name: 
-          type: string 
-          description: A name for the stack. 
-        source: 
-          "$ref": "../StackSource.yml"  
+description: Parameters for updating a stack.
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        name:
+          type: string
+          description: A name for the stack.
+        source:
+          $ref: "../StackSource.yml"

--- a/components/schemas/vms/sos/VirtualMachineSosToken.yml
+++ b/components/schemas/vms/sos/VirtualMachineSosToken.yml
@@ -10,14 +10,14 @@ required:
   - valid
 properties:
   id:
-    "$ref": "../../ID.yml"
+    $ref: "../../ID.yml"
   virtual_machine_id:
     type: string
     description: The ID of the virtual machine being connected to.
   hub_id:
-    "$ref": "../../HubID.yml"
+    $ref: "../../HubID.yml"
   creator:
-    "$ref": "../../creators/CreatorScope.yml"
+    $ref: "../../creators/CreatorScope.yml"
   events:
     title: SSHTokenEvents
     type: object
@@ -29,13 +29,13 @@ properties:
     properties:
       created:
         description: The timestamp of when the serial-over-SSH token was created.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       used:
         description: The timestamp of when the serial-over-SSH token was used.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
       expires:
         description: The timestamp of when the serial-over-SSH token expires.
-        "$ref": "../../DateTime.yml"
+        $ref: "../../DateTime.yml"
   valid:
     type: boolean
     description: A boolean where true represents the token as being a valid token to be used for connection.

--- a/components/schemas/vms/task/VirtualMachineReconfigureAction.yml
+++ b/components/schemas/vms/task/VirtualMachineReconfigureAction.yml
@@ -10,4 +10,4 @@ properties:
       - reconfigure
     description: The action to take.
   contents:
-    "$ref": "../config/VirtualMachineConfig.yml"
+    $ref: "../config/VirtualMachineConfig.yml"

--- a/internal/paths/environment/containers.yml
+++ b/internal/paths/environment/containers.yml
@@ -21,4 +21,4 @@ get:
               data:
                 type: array
                 items:
-                  "$ref": "../../../components/schemas/containers/Container.yml"
+                  $ref: "../../../components/schemas/containers/Container.yml"

--- a/internal/paths/environment/environment.yml
+++ b/internal/paths/environment/environment.yml
@@ -19,4 +19,4 @@ get:
               - data
             properties:
               data:
-                "$ref": "../../../components/schemas/environments/Environment.yml"
+                $ref: "../../../components/schemas/environments/Environment.yml"

--- a/internal/paths/environment/instances.yml
+++ b/internal/paths/environment/instances.yml
@@ -21,4 +21,4 @@ get:
               data:
                 type: array
                 items:
-                  "$ref": "../../../components/schemas/containers/instances/Instance.yml"
+                  $ref: "../../../components/schemas/containers/instances/Instance.yml"

--- a/internal/paths/sdn/environments.yml
+++ b/internal/paths/sdn/environments.yml
@@ -21,4 +21,4 @@ get:
               data:
                 type: array
                 items:
-                  "$ref": "../../../components/schemas/environments/Environment.yml"
+                  $ref: "../../../components/schemas/environments/Environment.yml"

--- a/internal/paths/sdn/instances.yml
+++ b/internal/paths/sdn/instances.yml
@@ -21,4 +21,4 @@ get:
               data:
                 type: array
                 items:
-                  "$ref": "../../../components/schemas/containers/instances/Instance.yml"
+                  $ref: "../../../components/schemas/containers/instances/Instance.yml"

--- a/internal/paths/sdn/networks.yml
+++ b/internal/paths/sdn/networks.yml
@@ -20,4 +20,4 @@ get:
               data:
                 type: array
                 items:
-                  "$ref": "../../../components/schemas/sdn/networks/Network.yml"
+                  $ref: "../../../components/schemas/sdn/networks/Network.yml"

--- a/internal/paths/server/instances.yml
+++ b/internal/paths/server/instances.yml
@@ -21,4 +21,4 @@ get:
               data:
                 type: array
                 items:
-                  "$ref": "../../../components/schemas/containers/instances/Instance.yml"
+                  $ref: "../../../components/schemas/containers/instances/Instance.yml"

--- a/platform/paths/billing/orders/includes/BillingOrderIncludes.yml
+++ b/platform/paths/billing/orders/includes/BillingOrderIncludes.yml
@@ -2,4 +2,4 @@ title: BillingOrderIncludes
 type: object
 properties:
   promo_codes:
-    "$ref": ../../../../../components/schemas/includes/PromoCodeInclude.yml
+    $ref: ../../../../../components/schemas//includes/IncludedPromoCodes.yml

--- a/platform/paths/containers/containers.yml
+++ b/platform/paths/containers/containers.yml
@@ -168,7 +168,7 @@ post:
               type: boolean
               description: A boolean where true represents this Container is stateful.
             config:
-              "$ref": "../../../components/schemas/containers/config/Config.yml"
+              $ref: "../../../components/schemas/containers/config/Config.yml"
             lock:
               type: boolean
               description: When set to true, prevents this Container from being deleted.

--- a/platform/paths/dns/records/includes/RecordIncludes.yml
+++ b/platform/paths/dns/records/includes/RecordIncludes.yml
@@ -3,7 +3,7 @@ description: All includable resources linkable to the given records.
 type: object
 properties:
   creators:
-    $ref: ../../../../../components/schemas/includes/CreatorInclude.yml
+    $ref: ../../../../../components/schemas/includes/CreatorIncludes.yml
   containers:
     type: object
     additionalProperties:

--- a/platform/paths/environments/environment.yml
+++ b/platform/paths/environments/environment.yml
@@ -61,9 +61,9 @@ get:
                 type: object
                 properties:
                   creators:
-                    $ref: ../../../components/schemas/includes/CreatorInclude.yml
+                    $ref: ../../../components/schemas/includes/CreatorIncludes.yml
                   clusters:
-                    $ref: ../../../components/schemas/includes/ClusterIncludes.yml
+                    $ref: ../../../components/schemas/includes/IncludedClusters.yml
     default:
       $ref: ../../../components/responses/errors/DefaultError.yml
 

--- a/platform/paths/environments/environments.yml
+++ b/platform/paths/environments/environments.yml
@@ -88,7 +88,7 @@ get:
                 type: object
                 properties:
                   creators:
-                    $ref: ../../../components/schemas/includes/CreatorInclude.yml
+                    $ref: ../../../components/schemas/includes/CreatorIncludes.yml
     default:
       $ref: ../../../components/responses/errors/DefaultError.yml
 

--- a/platform/paths/environments/services/loadbalancer/telemetry/includes/controllers.yml
+++ b/platform/paths/environments/services/loadbalancer/telemetry/includes/controllers.yml
@@ -3,10 +3,10 @@ description: Optionally included resources for load balancer controllers
 type: object
 properties:
   creators:
-    $ref: ../../../../../../../components/schemas/includes/CreatorInclude.yml
+    $ref: ../../../../../../../components/schemas/includes/CreatorIncludes.yml
   stack_builds:
-    $ref: ../../../../../../../components/schemas/includes/StackBuildIncludes.yml
+    $ref: ../../../../../../../components/schemas/includes/IncludedStackBuilds.yml
   stacks:
-    $ref: ../../../../../../../components/schemas/includes/StackIncludes.yml
+    $ref: ../../../../../../../components/schemas/includes/IncludedStacks.yml
   sources:
-    $ref: ../../../../../../../components/schemas/includes/ImageSourceIncludes.yml
+    $ref: ../../../../../../../components/schemas/includes/IncludedImageSources.yml

--- a/platform/paths/pipelines/run.yml
+++ b/platform/paths/pipelines/run.yml
@@ -47,6 +47,6 @@ get:
                 type: object
                 properties:
                   creators:
-                    "$ref": "../../../components/schemas/includes/CreatorInclude.yml"
+                    $ref: "../../../components/schemas/includes/CreatorIncludes.yml"
     default:
       $ref: ../../../components/responses/errors/DefaultError.yml

--- a/platform/paths/pipelines/runs.yml
+++ b/platform/paths/pipelines/runs.yml
@@ -47,6 +47,6 @@ get:
                 type: object
                 properties:
                   creators:
-                    "$ref": "../../../components/schemas/includes/CreatorInclude.yml"
+                    $ref: "../../../components/schemas/includes/CreatorIncludes.yml"
     default:
       $ref: ../../../components/responses/errors/DefaultError.yml

--- a/platform/paths/virtual-machines/includes/VirtualMachineIncludes.yml
+++ b/platform/paths/virtual-machines/includes/VirtualMachineIncludes.yml
@@ -3,7 +3,7 @@ description: All includable resources linkable to the given virtual machine.
 type: object
 properties:
   creators:
-    $ref: ../../../../components/schemas/includes/CreatorInclude.yml
+    $ref: ../../../../components/schemas/includes/CreatorIncludes.yml
   environments:
     type: object
     additionalProperties:

--- a/platform/paths/virtual-machines/includes/VirtualMachineSshIncludes.yml
+++ b/platform/paths/virtual-machines/includes/VirtualMachineSshIncludes.yml
@@ -3,7 +3,7 @@ description: All includable resources linkable to the given virtual machine SSH 
 type: object
 properties:
   creators:
-    $ref: ../../../../components/schemas/includes/CreatorInclude.yml
+    $ref: ../../../../components/schemas/includes/CreatorIncludes.yml
   environments:
     type: object
     additionalProperties:

--- a/platform/paths/virtual-machines/virtual-machines.yml
+++ b/platform/paths/virtual-machines/virtual-machines.yml
@@ -173,7 +173,7 @@ post:
             image:
               $ref: ../../../components/schemas/vms/images/VirtualMachineImage.yml
             config:
-              "$ref": ../../../components/schemas/vms/config/VirtualMachineConfig.yml
+              $ref: ../../../components/schemas/vms/config/VirtualMachineConfig.yml
             lock:
               type: boolean
               description: Prevents this virtual machine from being deleted when true.

--- a/stackspec/stackspec.json
+++ b/stackspec/stackspec.json
@@ -1,1 +1,5154 @@
-{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"StackSpec","description":"A Cycle stack file is an \"environment as code\". This allows an environment to be generated consistently based on a fixed specification. \nStack files can describe multiple containers and their configurations, environment service settings, scoped variables, and important metadata.\n","type":"object","required":["version","containers"],"properties":{"version":{"type":"string","description":"The version of the Cycle stack file used.","enum":["1.0"]},"about":{"oneOf":[{"type":["object","null"],"required":["description","version"],"properties":{"version":{"type":"string","description":"A custom, user-defined version of the stack."},"description":{"type":"string","description":"Custom, user-defined details about this stack."}}},{"title":"StackVariable","description":"A variable specified in a stack spec.","pattern":"\\\"?{{(\\$)?([a-z0-9\\-]+)}}\\\"?","type":"string","examples":["{{$stack-variable}}"]}]},"scoped_variables":{"description":"Describes variables that are assigned to one or more containers at runtime. Can be assigned as an environment variable, written as a file inside the container(s), or accessed over the internal API.","oneOf":[{"type":["array","null"],"items":{"title":"StackSpecScopedVariable","type":"object","required":["identifier","scope","access"],"properties":{"identifier":{"oneOf":[{"title":"Identifier","type":"string","description":"A human-readable identifier used to refer to a resource, where using the official ID may be inconvenient.\nThe identifier is automatically tokenized from the name/relevant field of the resource if one is not provided. For example, a container named \"My Container\" will\nhave the identifier of `my-container` and is automatically created by the platform.\n\nThe identifier does not have to be unique.\n"},{"$ref":"#/properties/about/oneOf/1"}]},"scope":{"oneOf":[{"type":"object","required":["containers"],"properties":{"containers":{"description":"Describes the containers that have access to this scoped variable.","oneOf":[{"type":"object","required":["global"],"properties":{"global":{"description":"If true, all containers in the environment will have access to this variable.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"ids":{"description":"A list of container IDs that are granted access to this variable.","oneOf":[{"type":["array","null"],"items":{"type":"string"}},{"$ref":"#/properties/about/oneOf/1"}]},"identifiers":{"description":"A list of container identifiers that are granted access to this variable.","oneOf":[{"type":["array","null"],"items":{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/identifier/oneOf/0"}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"access":{"oneOf":[{"type":"object","properties":{"env_variable":{"description":"Grants access to this variable from within a container as an environment variable.","oneOf":[{"type":"object","required":["key"],"properties":{"key":{"description":"The environment variable inside the container that stores the value of the variable.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"internal_api":{"description":"Grants access to this variable over the Internal API.","oneOf":[{"type":["object","null"],"properties":{"duration":{"description":"Sets the duration that this variable can be accessed over the Internal API, after container start. Provides additional security as sensitive data can only be accessed for a limited time.","anyOf":[{"title":"Duration","type":"string","description":"A string signifying a duration of time. Valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\", \"d\", \"w\", \"y\".","examples":["72h45m2s"]},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"file":{"description":"Grants access to this variable as a file inside the container.","oneOf":[{"type":["object","null"],"required":["decode","path"],"properties":{"decode":{"description":"When true, Cycle will interpret this variable as a base-64 encoded string, and decode it before writing it to the file inside the container.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"path":{"description":"The absolute path to write the variable to (including file name). If `null`, it will be written to `/var/run/cycle/variables/{variable-identifier}`.","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}],"examples":["/var/run/cycle/variables/<myVariable>"]},"permissions":{"oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}],"description":"A linux file mode that will be set on the injected file.","examples":["0644"]},"uid":{"oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}],"description":"The linux UID to set on the file.","examples":[777]},"gid":{"oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}],"description":"The linux GID to set on the file.","examples":[777]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"source":{"anyOf":[{"type":"object","description":"Describes the source/value of the variable.\n- **raw**: Directly set the value of the variable in the stack. - **url**: Cycle will fetch the variable content from a remote source when the container starts.\n","discriminator":{"propertyName":"type","mapping":{"url":"./StackSpecScopedVariableUrlSource.yml","raw":"./StackSpecScopedVariableRawSource.yml"}},"oneOf":[{"title":"StackSpecScopedVariableUrlSource","type":"object","description":"A variable who's value is fetched from a URL when the container starts.","required":["type","details"],"properties":{"type":{"type":"string","description":"The type of scoped variable.","enum":["url"]},"details":{"oneOf":[{"type":"object","required":["url","headers","auth_token_url"],"properties":{"url":{"description":"The URL to call to fetch the value.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"headers":{"description":"Additional headers that can be attached to the URL request. Useful for adding meta-data to third-party services.","oneOf":[{"type":"object","additionalProperties":{}},{"$ref":"#/properties/about/oneOf/1"}]},"auth_token_url":{"description":"A URL that can be provided to authenticate with a third party secret service. Cycle will make a request to this URL before fetching the secret URL, and use the response as the value of an Authorization header when requesting the secret.","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"title":"StackSpecScopedVariableRawSource","type":"object","description":"A variable with a hard-coded value.","required":["type","details"],"properties":{"type":{"description":"The type of scoped variable.","type":"string","enum":["raw"]},"details":{"oneOf":[{"type":"object","required":["value","blob"],"properties":{"value":{"description":"The value of the variable.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"blob":{"description":"A boolean where true represents the text the user is entering will be multi line.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"secret":{"oneOf":[{"type":["object","null"],"properties":{"iv":{"description":"A string describing the IV Hex associated with the encryption of the variable.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"hint":{"description":"A user specified hint that will suggest what the encryption key might be","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}}]},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}}},{"$ref":"#/properties/about/oneOf/1"}]},"containers":{"oneOf":[{"type":"object","description":"A mapping of containers that will be deployed as a part of this stack. The key is used as the container's identifier.","additionalProperties":{"title":"StackSpecContainer","description":"A container template defined within a stack.","type":"object","required":["name","image","config","stateful"],"properties":{"name":{"type":"string","description":"The human-readable name of this container."},"image":{"x-ogen-name":"StackSpecContainerImageProperty","description":"Details about the image used for this container.","oneOf":[{"title":"StackSpecContainerImage","type":"object","required":["origin"],"properties":{"name":{"description":"The human-readable name of this image.","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"origin":{"description":"Instructions on how to fetch or build this image.","oneOf":[{"title":"StackSpecImageOrigin","type":"object","description":"The origin of the image.","discriminator":{"propertyName":"type","mapping":{"docker-hub":"../../components/schemas/images/origins/dockerHub/DockerHubOrigin.yml","docker-file":"../../components/schemas/images/origins/dockerFile/DockerFileOrigin.yml","docker-registry":"../../components/schemas/images/origins/dockerRegistry/DockerRegistryOrigin.yml","oci-registry":"../../components/schemas/images/origins/ociRegistry/OciRegistryOrigin.yml","cycle-source":"../../components/schemas/images/origins/cycleSource/CycleSourceOrigin.yml"}},"oneOf":[{"title":"DockerHubOrigin","type":"object","description":"An image origin where the image is pulled from DockerHub.","required":["type","details"],"properties":{"type":{"type":"string","enum":["docker-hub"]},"details":{"type":"object","required":["target"],"properties":{"existing":{"anyOf":[{"$ref":"#/properties/containers/oneOf/0/additionalProperties/properties/image/oneOf/0/properties/origin/oneOf/0/oneOf/2/properties/details/properties/existing"},{"type":"null"}]},"target":{"type":"string","description":"The DockerHub target string. ex - `mysql:5.7`"},"username":{"type":"string","description":"For authentication, a username."},"token":{"type":"string","description":"For authentication, a token."}}}}},{"title":"DockerFileOrigin","type":"object","description":"An image origin where the image is built from a Dockerfile located in a git repository.","required":["type","details"],"properties":{"type":{"type":"string","enum":["docker-file"]},"details":{"type":"object","properties":{"existing":{"anyOf":[{"$ref":"#/properties/containers/oneOf/0/additionalProperties/properties/image/oneOf/0/properties/origin/oneOf/0/oneOf/2/properties/details/properties/existing"},{"type":"null"}]},"repo":{"anyOf":[{"title":"RepoSourceType","type":"object","description":"Information about the repository.","required":["url"],"properties":{"url":{"type":"string","description":"The URL of the repository."},"branch":{"type":"string","description":"An optional branch arguement.  Default value is `master`."},"auth":{"anyOf":[{"type":"null"},{"type":"object","description":"Authentication information for the repository.","discriminator":{"propertyName":"type","mapping":{"http":"../CredentialsHTTP.yml","ssh":"../CredentialsSSH.yml"}},"oneOf":[{"title":"HTTPSourceCredentials","type":"object","required":["type","credentials"],"properties":{"type":{"type":"string","enum":["http"]},"credentials":{"type":"object","description":"Authentication credentails for the Dockerfile image source type when authenticating over HTTP.","required":["username","password"],"properties":{"username":{"type":"string","description":"For authentication, the username."},"password":{"type":"string","description":"For authentication, the password."}}}}},{"title":"SSHSourceCredentials","type":"object","required":["type","credentials"],"properties":{"type":{"type":"string","enum":["ssh"]},"credentials":{"type":"object","description":"Authentication credentials for the Dockerfile image source type when authenticating with SSH.","required":["username","passphrase","private_key"],"properties":{"username":{"type":"string","description":"The username for the repo service, that is used to authenticate an ssh key."},"passphrase":{"type":"string","description":"The passphrase used for the key."},"private_key":{"type":"string","description":"A pem encoded private key."}}}}}]}]},"ref":{"oneOf":[{"type":"object","description":"Repository reference information.","required":["type","value"],"properties":{"type":{"type":"string","description":"The type of reference being used."},"value":{"type":"string","description":"The value for the given reference type."}}},{"type":"null"}]}}},{"type":"null"}]},"targz_url":{"type":["string","null"],"description":"An endpoint that serves the tar file."},"context_dir":{"type":["string","null"],"description":"The path to the directory to use as the context when building the image."},"build_file":{"type":["string","null"],"description":"The path to the Dockerfile to be used for buiding the image."},"credentials":{"anyOf":[{"title":"DockerfileCredentails","description":"An array of credentials objects to be used when authenticating against private images used by the Dockerfile.","type":"array","items":{"type":"object","description":"Credentials object used for authentication of indirect resources such as private parent images.","properties":{"url":{"type":"string","description":"The url the resource is located at."},"username":{"type":"string","description":"A username for authentication."},"token":{"type":"string","description":"A token for authentication."}}}},{"type":"null"}]}}}}},{"title":"DockerRegistryOrigin","type":"object","description":"An image origin where the image is pulled from a private Docker registry.","required":["type","details"],"properties":{"type":{"type":"string","enum":["docker-registry"]},"details":{"type":"object","required":["target","url"],"properties":{"existing":{"title":"ExistingSource","type":"object","description":"In a stack, specifies an image source ID from which Cycle will derive any values not specified in the stack file. This is useful for avoiding direct placement of credentials in a stack file, for example.","properties":{"source_id":{"$ref":"#/properties/containers/oneOf/0/additionalProperties/properties/image/oneOf/0/properties/origin/oneOf/0/oneOf/4/properties/details/properties/source_id","description":"The ID of the image source this image should be built from."}}},"target":{"type":"string","description":"The image name on the registry."},"url":{"type":"string","description":"The url of the remote registry."},"username":{"type":"string","description":"For authentication, a username."},"token":{"type":"string","description":"For authentication, a token."},"password":{"type":"string","description":"For authentication, a password."}}}}},{"title":"OciRegistryOrigin","type":"object","description":"An image origin that pulls images fro an OCI-compatible registry. Also used for provider-native registries, such as AWS ECR.","required":["type","details"],"properties":{"type":{"type":"string","enum":["oci-registry"]},"details":{"type":"object","required":["target","url"],"properties":{"existing":{"$ref":"#/properties/containers/oneOf/0/additionalProperties/properties/image/oneOf/0/properties/origin/oneOf/0/oneOf/2/properties/details/properties/existing"},"target":{"type":"string","description":"The image name on the registry."},"url":{"type":"string","description":"The url of the remote registry."},"auth":{"oneOf":[{"title":"RegistryAuth","type":"object","description":"Authentication details for a third party image registry/source.","discriminator":{"propertyName":"type","mapping":{"user":"RegistryAuthUser.yml","provider":"RegistryAuthProvider.yml","webhook":"RegistryAuthWebhook.yml"}},"oneOf":[{"title":"RegistryAuthUser","description":"User/token based credentials for authentication to a third-party image source.","type":"object","required":["type","details"],"properties":{"type":{"type":"string","enum":["user"]},"details":{"type":"object","properties":{"username":{"type":"string"},"token":{"type":"string"}}}}},{"title":"RegistryAuthProvider","description":"Credentials for authentication to a provider-native image registry, such as AWS ECR.","type":"object","required":["type","details"],"properties":{"type":{"type":"string","enum":["provider"]},"details":{"type":"object","required":["flavor","credentials"],"properties":{"flavor":{"type":"string","enum":["ecr"]},"credentials":{"title":"RegistryAuthProviderCredentials","type":"object","properties":{"region":{"type":"string"},"namespace":{"type":"string"},"api_key":{"type":"string"},"secret":{"type":"string"},"subscription_id":{"type":"string"},"client_id":{"type":"string"},"config":{"type":"string","description":"A base64'd string of additional configuration options."}}}}}}},{"title":"RegistryAuthWebhook","description":"Webhook-based authentication to the provided URL. This webhook expects to receive a base-64 string that when decoded is in the format `username:password`","type":"object","required":["type","details"],"properties":{"type":{"type":"string","enum":["webhook"]},"details":{"type":"object","required":["url"],"properties":{"url":{"type":"string"}}}}}]},{"type":"null"}]}}}}},{"title":"CycleSourceOrigin","type":"object","description":"An image origin that references an image source on Cycle. \n\nThis origin will never be embedded in an image source. It is for use in stacks, describing an image which is already a part of an image source on Cycle.\n","required":["type","details"],"properties":{"type":{"type":"string","enum":["cycle-source"]},"details":{"type":"object","required":["source_id"],"properties":{"source_id":{"description":"The ID referencing the image source where this image originated.","title":"ID","type":"string","format":"objectid","examples":["651586fca6078e98982dbd90"]}}}}}]},{"$ref":"#/properties/about/oneOf/1"}]},"build":{"description":"Additional details applied when building an image.","oneOf":[{"type":["object","null"],"properties":{"use_disk":{"type":"boolean","description":"If true, will skip using /dev/shm when building an image on factory, which is limited to `6.5GB`. Allows for building much larger images, up to `20GB`.","default":false},"args":{"description":"A map of build arguments applied to the image at build time.","oneOf":[{"type":"object","additionalProperties":{"type":"string"}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"builder":{"description":"A specific builder to use. By default, Cycle uses its factory service and a standard build command to build images, but this can be enhanced by using an image builder integration.","oneOf":[{"type":["object","null"],"required":["integration_id"],"properties":{"integration_id":{"description":"The ID of the integration to use when building the image. The integration must support image building to be compatible.","$ref":"#/properties/containers/oneOf/0/additionalProperties/properties/volumes/oneOf/0/items/properties/external/anyOf/0/properties/id/oneOf/0"}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"annotations":{"oneOf":[{"type":["object","null"],"description":"Additional user-provided meta data about the container.","additionalProperties":{}},{"$ref":"#/properties/about/oneOf/1"}]},"stateful":{"description":"Whether or not to mark the container as stateful when deployed. Stateful containers can utilize volumes (stateful data) and are generally used for running databases or other data management applications.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"config":{"oneOf":[{"type":"object","description":"Configuration options for this container that will be applied when deployed as part of the stack.","title":"StackContainerConfig","required":["network","deploy"],"properties":{"network":{"oneOf":[{"title":"StackSpecContainerConfigNetwork","x-ogen-name":"StackSpecContainerConfigNetwork","description":"Stack configuration options related to the container's network.","type":"object","required":["public","hostname"],"properties":{"public":{"description":"The level of public network access this container should have.","oneOf":[{"type":"string","enum":["enable","disable","egress-only"]},{"$ref":"#/properties/about/oneOf/1"}]},"hostname":{"description":"The hostname of the container. This is how it can be referenced by other containers in the same environment.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"ports":{"description":"A list of port mappings on this container.","oneOf":[{"type":"array","items":{"type":"string"},"examples":["80:80","443:80","3000"]},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"deploy":{"oneOf":[{"title":"StackSpecContainerConfigDeploy","type":"object","description":"Stack configuration options related to how the container behaves over its lifecycle (startup, shutdown, health checks, etc).","required":["instances"],"properties":{"instances":{"description":"The number of desired instances to deploy.","oneOf":[{"type":"integer"},{"$ref":"#/properties/about/oneOf/1"}]},"strategy":{"description":"The strategy Cycle will apply when deploying instances of this container.\n\n- ** resource-density **: Cycle will distribute instances across servers to maintain balanced resource usage.\n- ** high-availability **: Cycle will deploy instances across servers with an emphasis on geographic and physical separation. Requires multiple locations.\n- ** distributed **: Cycle will deploy instances across servers with an emphasis on physical separation. Does not require multiple locations.\n- ** first-available **: Cycle will deploy one instance to every server that matches the specified criteria. (default)\n- ** node **: Cycle will deploy one instance to every server that matches the specified criteria.\n- ** edge **: Cycle will prioritize geographic distribution of instances.\n- ** function **: Every ingress request/connection receives its own instance. \n- ** manual **: Cycle will not make any decisions on where instances are deployed. Instead, instances must be deployed manually using the portal or API.\n","oneOf":[{"type":["string","null"],"enum":["resource-density","manual","high-availability","first-available","node","edge","function"],"default":"first-available"},{"$ref":"#/properties/about/oneOf/1"}]},"function":{"description":"Configuration options for containers using the 'function' deployment strategy.","oneOf":[{"type":["object","null"],"properties":{"max_pool_size":{"description":"The maximum number of instances that Cycle can pre-allocate (includes auto-scaled instances).","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"max_shard_concurrency":{"description":"For each shard (scheduler), the maximum number of tasks it can run in parallel.","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"max_runtime":{"description":"The maximum amount of time a function instance can run before timing out.","anyOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"max_queue_time":{"description":"The maximum amount of time Cycle will wait for an instance to be available.","anyOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"stateful":{"description":"Configuration options for stateful containers.","oneOf":[{"type":["object","null"],"required":["options"],"properties":{"options":{"description":"Stateful container options.","type":["object","null"],"properties":{"use_base_hostname":{"description":"When enabled, instances will utilize stateless base hostnames instead of being prefixed with a unique ID.","type":["boolean","null"]}}}}},{"$ref":"#/properties/about/oneOf/1"}]},"constraints":{"description":"Configuration options that provide the ability to set restrictions on which nodes instances of this container are able to be deployed to. (i.e. if you have a GPU container, it should only go on nodes with a GPU).","oneOf":[{"type":["object","null"],"properties":{"node":{"type":["object","null"],"required":["tags"],"properties":{"tags":{"description":"Tags applied to a node. Cycle generates some automatically, but additional, custom tags can be applied on a per-node basis.","oneOf":[{"type":"object","properties":{"any":{"description":"If a node has at least one of these tags, it is considered a valid deployment target for this container.","oneOf":[{"type":"array","items":{"type":"string"}},{"$ref":"#/properties/about/oneOf/1"}]},"all":{"description":"A node must have **ALL** of these tags to be considered a valid deployment target for this container.","oneOf":[{"type":"array","items":{"type":"string"}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}}}},{"$ref":"#/properties/about/oneOf/1"}]},"shutdown":{"description":"Configuration options for how this container behaves during shutdown.","oneOf":[{"type":["object","null"],"properties":{"graceful_timeout":{"description":"How long the platform will wait for a container to stop gracefully.","anyOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"signals":{"oneOf":[{"type":"array","description":"Signals that should be sent to the container on shutdown.","items":{"title":"ShutdownSignal","type":"string","description":"Process signals that Cycle can be configured to send to the container on a shutdown event.","enum":["SIGTERM","SIGINT","SIGUSR1","SIGUSR2","SIGHUP","SIGQUIT"]}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"startup":{"description":"Configuration options for how this container behaves during startup.","oneOf":[{"type":["object","null"],"properties":{"delay":{"description":"How long the platform will wait before sending the start signal to the given container.","anyOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"update":{"description":"Configurations for how the container behaves during updates.","oneOf":[{"type":["object","null"],"properties":{"stagger":{"anyOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}],"description":"When set, Cycle will pick a random time from `0 - this duration`, and stagger the instances so they all start at different times (up to the time specified here)."}}},{"$ref":"#/properties/about/oneOf/1"}]},"restart":{"description":"Configuration options for how Cycle should handle restarting this container (i.e. in case the process inside the container dies).","oneOf":[{"type":["object","null"],"required":["condition","delay","max_attempts"],"properties":{"condition":{"description":"Under what circumstances Cycle should try to restart this container.","oneOf":[{"type":"string","enum":["always","never","failure"]},{"$ref":"#/properties/about/oneOf/1"}]},"delay":{"description":"How long the platform will wait between restart attempts.","oneOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"}]},"max_attempts":{"description":"The maximum number of restart attempts Cycle will make.","oneOf":[{"type":"integer"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"health_check":{"description":"Configuration options for automated container health checks.","oneOf":[{"type":["object","null"],"required":["command","retries","interval","timeout","restart"],"properties":{"command":{"description":"The command or script to run to verify the health of the container. This script is run inside the container by Cycle.\nThis command accepts two types of entries:\n- The first is a reference to a script that already lives in the container filesystem. This can be defined by giving the full path to the script as the value.   - The second format is an inline script.  If you need the code to execute within a shell, wrap the commands in escaped quotes like this `\"\\\"curl -s -o /dev/console -w \\\"%{http_code}\\\" http://localhost:3000/_health | grep '200'  && exit 0 || exit 1\\\"\"`.  Do not use the `/bin/sh -c <commands>` format, this will not be accepted.\n","oneOf":[{"type":"string","examples":["/bin/sh healthcheck.sh"]},{"$ref":"#/properties/about/oneOf/1"}]},"retries":{"description":"The number of times to retry the command before marking an instance unhealthy.","oneOf":[{"type":"integer"},{"$ref":"#/properties/about/oneOf/1"}]},"interval":{"description":"How long to wait between running health checks.","oneOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"}]},"timeout":{"description":"How long before a health check attempt times out.","oneOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"}]},"restart":{"description":"A boolean where true represents the desire for the container to restart if any instance is unhealthy.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"delay":{"anyOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}],"description":"How long to wait after a container start event before running health checks."}}},{"$ref":"#/properties/about/oneOf/1"}]},"telemetry":{"description":"Configuration options for how the instance telemetry (CPU usage, etc) is handled.","oneOf":[{"type":["object","null"],"required":["disable"],"properties":{"retention":{"anyOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}],"description":"How long telemetry data should be retained."},"interval":{"anyOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}],"description":"The duration between samples."},"webhook":{"description":"A URL where Cycle will send telemetry data to. The payload will be an instance resource snapshot.","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"disable":{"description":"If true, Cycle will not aggregate telemetry for this container's instances.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"scaling":{"description":"Configuration options for auto-scaling.","anyOf":[{"title":"StackSpecContainerConfigScaling","type":"object","description":"Stack configuration options for auto-scaling.","required":["autoscale_group","instances","window","thresholds"],"properties":{"autoscale_group":{"anyOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/identifier/oneOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}],"description":"The identifier of the auto-scaling group assigned to this container. The auto-scale group determines which infrastructure this container can spin up if it needs more resources to meet demand. Setting it to `null` will limit auto-scaling to only instances."},"instances":{"oneOf":[{"type":"object","description":"Describes the criteria for deploying new instances when an auto-scale criteria is met.","required":["max","max_server","min_ttl"],"properties":{"max":{"description":"Maximum additional instances the auto-scaler will run at any time.","oneOf":[{"type":"integer"},{"$ref":"#/properties/about/oneOf/1"}]},"max_server":{"description":"Minimum number of instances per server.","oneOf":[{"type":"integer"},{"$ref":"#/properties/about/oneOf/1"}]},"min_ttl":{"description":"Minimum amount of time an instance will live.","oneOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"window":{"description":"Duration in which the auto-scaler will watch for changes.","oneOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"}]},"thresholds":{"description":"An array of rules that dictate when a scaling event will be triggered.","oneOf":[{"type":"array","items":{"title":"StackSpecContainerScaleThreshold","type":"object","description":"Discriminated union describing the different types of scaling threshold and their respective details","discriminator":{"propertyName":"type","mapping":{"ram":"./StackSpecContainerScaleThresholdRam.yml","cpu":"./StackSpecContainerScaleThresholdCpu.yml","custom":"./StackSpecContainerScaleThresholdCustom.yml","network-connections":"./StackSpecContainerScaleThresholdNetworkConnections.yml","network-requests":"./StackSpecContainerScaleThresholdNetworkRequests.yml","network-throughput":"./StackSpecContainerScaleThresholdNetworkThroughput.yml"}},"oneOf":[{"title":"StackSpecContainerScaleThresholdRam","type":"object","description":"Describes the RAM threshold at which scaling will occur.","required":["type","details"],"properties":{"type":{"type":"string","enum":["ram"]},"details":{"type":"object","required":["usage"],"properties":{"usage":{"type":"string","description":"The target average RAM usage of all instances of this container. Going above this threshold will trigger a scaling event. This threshold must be greater than 25MB.","examples":["2G","25MB"]}}}}},{"title":"StackSpecContainerScaleThresholdCpu","type":"object","description":"Describes the CPU threshold at which scaling will occur.","required":["type","details"],"properties":{"type":{"type":"string","enum":["cpu"]},"details":{"type":"object","required":["utilization"],"properties":{"utilization":{"type":"integer"}}}}},{"title":"StackSpecContainerScaleThresholdNetworkConnections","type":"object","description":"Describes the network connections threshold at which scaling will occur.","required":["type","details"],"properties":{"type":{"type":"string","enum":["network-connections"]},"details":{"type":"object","required":["connections_total"],"properties":{"connections_total":{"type":"integer"}}}}},{"title":"StackSpecContainerScaleThresholdNetworkRequests","type":"object","description":"Describes the network requests threshold at which scaling will occur.","required":["type","details"],"properties":{"type":{"type":"string","enum":["network-requests"]},"details":{"type":"object","required":["requests_total"],"properties":{"requests_total":{"type":"integer"}}}}},{"title":"StackSpecContainerScaleThresholdNetworkThroughput","type":"object","description":"Describes the network throughput threshold at which scaling will occur.","required":["type","details"],"properties":{"type":{"type":"string","enum":["network-throughput"]},"details":{"type":"object","required":["private","bandwidth"],"properties":{"private":{"type":"boolean"},"bandwidth":{"type":"string","description":"The limit (maximum) amount of throughput each instance of the given container can use before triggering a scaling event.","examples":["1gbps","50mbps"]}}}}}]}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"runtime":{"anyOf":[{"title":"StackSpecContainerConfigRuntime","description":"Configuration options related to how the container behaves while it is running (environment variables, command overrides, kernel capabilities, etc. )","type":"object","properties":{"workdir":{"description":"The working directory to execute the command in.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"command":{"description":"The command to execute when this container starts. Will override the default specified in the container.","oneOf":[{"type":"object","properties":{"path":{"oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"args":{"oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"environment_vars":{"description":"A map of environment variables that will be injected into the container.","oneOf":[{"type":"object","additionalProperties":{"oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]}},{"$ref":"#/properties/about/oneOf/1"}]},"namespaces":{"description":"Container namespaces to apply. By default, all are applied. Removing/changing this can have security implications.","oneOf":[{"type":"array","items":{"type":"string","enum":["ipc","pid","uts","network","mount","user","cgroup"]}},{"$ref":"#/properties/about/oneOf/1"}]},"sysctl":{"description":"Sysctl options to apply.","oneOf":[{"type":"object","additionalProperties":{"oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]}},{"$ref":"#/properties/about/oneOf/1"}]},"rlimits":{"description":"RLIMIT options to apply.","oneOf":[{"type":"object","additionalProperties":{"type":"object","required":["hard","soft"],"properties":{"hard":{"oneOf":[{"type":"integer"},{"$ref":"#/properties/about/oneOf/1"}]},"soft":{"oneOf":[{"type":"integer"},{"$ref":"#/properties/about/oneOf/1"}]}}}},{"$ref":"#/properties/about/oneOf/1"}]},"seccomp":{"description":"Configuration options for seccomp. Cycle enables seccomp by default.","oneOf":[{"type":"object","required":["disable","rules"],"properties":{"disable":{"oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"rules":{"oneOf":[{"type":"array","items":{"oneOf":[{"type":"object","required":["capabilities","syscall"],"properties":{"capabilities":{"oneOf":[{"type":"object","required":["includes","excludes"],"properties":{"includes":{"oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"excludes":{"oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"syscall":{"oneOf":[{"type":"object","required":["names","action"],"properties":{"names":{"type":"array","items":{"type":"string"}},"action":{"type":"string","enum":["SCMP_ACT_KILL","SCMP_ACT_KILL_PROCESS","SCMP_ACT_KILL_THREAD","SCMP_ACT_TRAP","SCMP_ACT_ERRNO","SCMP_ACT_TRACE","SCMP_ACT_ALLOW","SCMP_ACT_LOG","SCMP_ACT_NOTIFY"]},"errnoRet":{"type":"integer"},"args":{"type":"array","items":{"type":"object","required":["index","value","op"],"properties":{"index":{"type":"integer"},"value":{"type":"integer"},"valuetwo":{"type":"integer"},"op":{"type":"string","enum":["SCMP_CMP_NE","SCMP_CMP_LT","SCMP_CMP_LE","SCMP_CMP_EQ","SCMP_CMP_GE","SCMP_CMP_GT","SCMP_CMP_MASKED_EQ"]}}}}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"host":{"description":"Configuration options regarding the underlying host.","oneOf":[{"type":["object","null"],"properties":{"expose_proc":{"description":"If true, Cycle will mount the `/proc` directory into the container, giving it access to the host metrics. This is useful if you're running i.e. a monitoring agent.","oneOf":[{"type":["boolean","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"expose_cgroups":{"description":"If true, Cycle will mount the host's `/sys/fs/cgroups` directory into the container at `/var/run/cycle/host/cgroups`.","oneOf":[{"type":["boolean","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"power_management":{"description":"If true, Cycle will give the container instances access via internal api to power off or reboot the host server.","oneOf":[{"type":["boolean","null"]},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"privileged":{"description":"If true, the container process will run in fully-privileged mode. **WARNING** This is considered insecure, and should only be done if you know what you're doing.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"capabilities":{"description":"Additional Linux kernel capabilities to apply to this container process.","oneOf":[{"type":"array","items":{"type":"string","enum":["CAP_CHOWN","CAP_FSETID","CAP_DAC_OVERRIDE","CAP_FOWNER","CAP_SETFCAP","CAP_SETGID","CAP_SETUID","CAP_KILL","CAP_MKNOD","CAP_NET_BIND_SERVICE","CAP_NET_RAW","CAP_AUDIT_WRITE","CAP_SYS_CHROOT","CAP_SETPCAP","CAP_DAC_READ_SEARCH","CAP_NET_ADMIN","CAP_NET_BROADCAST","CAP_SYS_ADMIN","CAP_SYS_MODULE","CAP_SYS_NICE","CAP_SYS_PACCT","CAP_SYS_PTRACE","CAP_SYS_RAWIO","CAP_SYS_RESOURCE","CAP_SYS_BOOT","CAP_SYS_TIME","CAP_SYS_TTY_CONFIG","CAP_SYSLOG","CAP_AUDIT_CONTROL","CAP_AUDIT_READ","CAP_IPC_LOCK","CAP_IPC_OWNER","CAP_LINUX_IMMUTABLE","CAP_MAC_ADMIN","CAP_MAC_OVERRIDE","CAP_BLOCK_SUSPEND","CAP_LEASE","CAP_WAKE_ALARM"]}},{"$ref":"#/properties/about/oneOf/1"}]},"rootfs":{"description":"Configuration options for the root filesystem.","oneOf":[{"type":"object","required":["readonly"],"properties":{"readonly":{"description":"If true, the container's filesystem will be read-only.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"devices":{"oneOf":[{"type":"object","properties":{"shm_size":{"oneOf":[{"type":"string","description":"The size of the shared host memory device (/dev/shm).","examples":["64M","128M","512M"]},{"type":"null"},{"$ref":"#/properties/about/oneOf/1"}]},"expose":{"anyOf":[{"type":"array","description":"An array of devices to expose to the container.","items":{"title":"StackSpecRuntimeExposedDevice","type":"object","description":"A host device exposed to the container during runtime.","required":["source","destination"],"properties":{"source":{"description":"The path to the device on the host.","oneOf":[{"type":"string","examples":["/dev/kvm","/dev/net/tun"]},{"$ref":"#/properties/about/oneOf/1"}]},"destination":{"description":"The path inside the container that the device is mapped to.","oneOf":[{"type":"string","examples":["/dev/kvm","/dev/net/tun"]},{"$ref":"#/properties/about/oneOf/1"}]},"options":{"anyOf":[{"type":"array","description":"Options passed when mounting the device.","items":{"type":"string","examples":["rbind","ro"]}},{"type":"null"},{"$ref":"#/properties/about/oneOf/1"}]}}}},{"type":"null"},{"$ref":"#/properties/about/oneOf/1"}]},"permissions":{"anyOf":[{"type":"array","description":"Rules for granting or denying access to a device node.","items":{"title":"StackSpecRuntimeDevicePermission","type":"object","description":"A rule that grants or denies access to a device node (e.g., Linux cgroup device rule). Controls which device type and major/minor numbers are allowed, and with what access.\n","required":["type","allow","access"],"properties":{"type":{"oneOf":[{"title":"StackSpecRuntimeDevicePermissionType","type":"string","description":"The class of device this rule applies to (for example, block devices or character devices).\n","enum":["b","c"]},{"$ref":"#/properties/about/oneOf/1"}]},"major":{"description":"Device major number.\n","oneOf":[{"type":["integer","null"],"format":"int64"},{"$ref":"#/properties/about/oneOf/1"}]},"minor":{"description":"Device minor number.\n","oneOf":[{"type":["integer","null"],"format":"int64"},{"$ref":"#/properties/about/oneOf/1"}]},"allow":{"oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}],"description":"Whether this rule allows (true) or denies (false) access."},"access":{"oneOf":[{"title":"StackSpecRuntimeDevicePermissionAccess","type":"string","description":"The access mode permitted by this rule. Common conventions use a combination of letters (e.g., r, w, m) to indicate read, write, and mknod capabilities.\n","pattern":"^[rwm]+$","examples":["r","rw","rwm"]},{"$ref":"#/properties/about/oneOf/1"}]}}}},{"type":"null"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"type":"null"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"resources":{"anyOf":[{"title":"StackSpecContainerConfigResources","description":"Configuration options for container resource limits and reserves.","type":"object","required":["cpu","ram"],"properties":{"cpu":{"oneOf":[{"type":"object","properties":{"shares":{"oneOf":[{"type":"object","required":["limit","reserve"],"properties":{"limit":{"oneOf":[{"type":"integer"},{"$ref":"#/properties/about/oneOf/1"}]},"reserve":{"oneOf":[{"type":"integer"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"cpus":{"type":"string"}}},{"$ref":"#/properties/about/oneOf/1"}]},"ram":{"oneOf":[{"type":"object","properties":{"limit":{"oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"reserve":{"oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"swappiness":{"oneOf":[{"type":"number"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"integrations":{"anyOf":[{"title":"StackSpecContainerConfigIntegrations","type":"object","description":"Configuration options for additional integrations/features that Cycle provides.","properties":{"webhooks":{"description":"Enable additional webhooks that Cycle will call out to during the course of a container's lifetime. All webhooks send a payload as an object containing the instance, container, server, and environment IDs.","oneOf":[{"type":["object","null"],"properties":{"events":{"description":"Webhooks that are triggered during a container event.","oneOf":[{"type":["object","null"],"properties":{"deploy":{"description":"Cycle will call this endpoint when the container is deployed.","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"start":{"description":"Cycle will call this endpoint when the container is started.","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"stop":{"description":"Cycle will call this endpoint when the container is stopped.","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"config":{"description":"The webhook to hit when the container's configuration is changed.","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"lets_encrypt":{"description":"When enabled, this integration will configure Let's Encrypt certificates that will be injected into the container at runtime. The certificates will be managed by the platform and renewed automatically.","oneOf":[{"type":["object","null"],"properties":{"certificate_path":{"oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"chain_path":{"oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"key_path":{"oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"bundle_path":{"oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"additional_certs_path":{"oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"files":{"description":"When enabled, Cycle will fetch and inject remote files into the container at the specified destination during runtime.","oneOf":[{"type":["array","null"],"items":{"type":"object","required":["source","destination"],"properties":{"source":{"oneOf":[{"$ref":"#/properties/about/oneOf/1"},{"type":"string"}]},"destination":{"oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]}}}},{"$ref":"#/properties/about/oneOf/1"}]},"backups":{"description":"When enabled, Cycle will automatically manage backups of this container. This is only available for stateful containers.","oneOf":[{"type":["object","null"],"required":["destination","backup","restore","retention"],"properties":{"integration_id":{"description":"An identifier of an integration that supports backups. All backups will be sent to this destination.","oneOf":[{"$ref":"#/properties/containers/oneOf/0/additionalProperties/properties/volumes/oneOf/0/items/properties/external/anyOf/0/properties/id/oneOf/0"},{"$ref":"#/properties/about/oneOf/1"}]},"backup":{"description":"Configuration options for how the container should be backed up.","oneOf":[{"type":"object","required":["command","timeout","cron_string"],"properties":{"command":{"description":"The command to run to capture a backup. The output sent to `STDOUT` will be captured and sent to the specified integration.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"timeout":{"description":"How long the backup will attempt to run before timing out.","anyOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"cron_string":{"description":"A cron string describing how often to run the backup command.","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"restore":{"description":"Configuration options for how the backup should be restored.","oneOf":[{"type":["object","null"],"required":["command","timeout"],"properties":{"command":{"oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"timeout":{"description":"The time in seconds for the restore to attempt to complete before timing out.","anyOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"retention":{"description":"How long the platform will keep backups. Default is 1 year.","anyOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}],"default":"365d"}}},{"$ref":"#/properties/about/oneOf/1"}]},"shared_file_systems":{"description":"When enabled, Cycle will mount a shared host directory into this container. The directory will be shared with all other containers that mount it.","oneOf":[{"type":["object","null"],"additionalProperties":{"oneOf":[{"type":"object","required":["writable","mount_point"],"properties":{"writable":{"oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"mount_point":{"oneOf":[{"$ref":"#/properties/about/oneOf/1"},{"type":"string"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"role":{"description":"The role applied to this container. **Not yet implemented**","type":["string","null"],"enum":["conductor"]},"volumes":{"description":"A list of configurations for volumes that will be attached to the container. Only applicable if the container is set to `stateful`.","oneOf":[{"type":["array","null"],"items":{"title":"StackSpecContainerVolume","description":"A container volume configuration.","type":"object","required":["destination"],"properties":{"local":{"description":"Configuration options for local volumes.","oneOf":[{"type":"object","required":["max_size"],"properties":{"max_size":{"description":"The maximum size this volume can grow to. Container volumes on Cycle are thinly provisioned, meaning this isn't an allocation - the volume will only use the space it needs up to this size.","oneOf":[{"type":"string","examples":["5G","500M"]},{"$ref":"#/properties/about/oneOf/1"}]},"storage_pool":{"description":"A boolean where true signifies using the largest drive over 2TB for the target server.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"external":{"anyOf":[{"type":"object","properties":{"id":{"oneOf":[{"title":"HybridIdentifier","type":"string","description":"Either a resource ID (objectid - i.e. 651586fca6078e98982dbd90) or a resource Identifier (human-readable)","examples":["my-image-source"]},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}],"description":"The ID of the external volume."}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"destination":{"description":"The path this volume should be mounted at inside the container.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"read_only":{"description":"If true, the container will be unable to write data to the volume.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"block_device":{"oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}],"description":"Indicates that the volume will be used as unformatted block storage.\n"},"remote_access":{"description":"Configuration options for setting up remote access to this volume via SFTP.","oneOf":[{"type":"object","required":["enable","password"],"properties":{"enable":{"description":"If true, this volume will be accessible over SFTP.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"ips":{"description":"A list of IPs that SFTP access will be limited to.","oneOf":[{"type":"array","items":{"type":"string"}},{"$ref":"#/properties/about/oneOf/1"}]},"webhook":{"description":"If set, Cycle will call out to this URL for authentication. Anything other than a 200 response will be considered a validation failure.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"password":{"description":"The password used for logging in to this volume via SFTP.","oneOf":[{"type":"object","required":["algorithm","data"],"properties":{"algorithm":{"description":"The algorithm the password is encoded with. `raw` means the password is plain-text.","oneOf":[{"type":"string","enum":["raw","sha512","md5"]},{"$ref":"#/properties/about/oneOf/1"}]},"data":{"description":"The password string.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}}},{"$ref":"#/properties/about/oneOf/1"}]},"deprecate":{"description":"If true, the container is marked as `deprecated`, and cannot be started anymore. Deprecated containers also don't count toward resource utilization.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"lock":{"description":"If true, the container is marked as `locked` and cannot be deleted in any way until the lock is lifted.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]}}}},{"$ref":"#/properties/about/oneOf/1"}]},"monitoring":{"description":"Monitoring options for containers within this stack.","oneOf":[{"title":"StackSpecMonitoringConfig","description":"Monitoring options for the stack build & containers within this stack.","type":"object","properties":{"logs":{"oneOf":[{"title":"StackSpecMonitoringLogs","description":"Log configuration for containers in this stack.","type":"object","properties":{"logs":{"oneOf":[{"type":"object","properties":{"drain":{"description":"When enabled, log drain allows logs to be exported to a third party service.","oneOf":[{"type":"object","required":["url","exclude_services"],"properties":{"url":{"description":"The URL to the third party logging service where logs will be sent.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"exclude_services":{"description":"If enabled, service logs will not be included in log drain.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"format":{"description":"The format Cycle will use to send the logs.","oneOf":[{"type":"string","enum":["ndjson-headers","ndjson-raw"]},{"type":"null"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"type":"null"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"type":"null"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"type":"null"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"services":{"description":"Settings for any auxillary services deployed as part of the environment, such as load balancer and discovery services.","oneOf":[{"title":"StackSpecServices","type":["object","null"],"properties":{"discovery":{"anyOf":[{"title":"StackSpecDiscoveryService","description":"Configuration options for the discovery service.","type":"object","additionalProperties":false,"properties":{"service":{"anyOf":[{"$ref":"#/properties/services/oneOf/0/properties/vpn/anyOf/0/properties/service/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"config":{"anyOf":[{"title":"StackSpecDiscoveryConfig","type":"object","properties":{"empty_set_delay":{"anyOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"dual_stack_legacy":{"description":"When enabled, discovery will return both IPv6 and IPv4 when in legacy mode.  Otherwise, only IPv4 will be returned.","anyOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"hosts":{"description":"A custom mapping of hosts - for forced resolution of specific IPs for a domain.","oneOf":[{"type":["object","null"],"additionalProperties":{"type":"object","properties":{"ipv4":{"oneOf":[{"type":["array","null"],"items":{"type":"string"}},{"$ref":"#/properties/about/oneOf/1"}]},"ipv6":{"oneOf":[{"type":["array","null"],"items":{"type":"string"}},{"$ref":"#/properties/about/oneOf/1"}]}}}},{"$ref":"#/properties/about/oneOf/1"}]},"custom_resolvers":{"description":"A list of custom DNS resolver strings.  Can specifify domains or ips.","anyOf":[{"type":"array","items":{"type":"string"}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"loadbalancer":{"anyOf":[{"title":"StackSpecLoadBalancerService","description":"Configuration options for the load balancer service.","type":"object","additionalProperties":false,"properties":{"service":{"anyOf":[{"$ref":"#/properties/services/oneOf/0/properties/vpn/anyOf/0/properties/service/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"config":{"anyOf":[{"title":"StackSpecLoadBalancerConfig","type":"object","description":"The config object for the loadbalancer service.","discriminator":{"propertyName":"type","mapping":{"haproxy":"types/haproxy/StackSpecHaProxyLbType.yml","v1":"types/v1/StackSpecV1LbType.yml","default":"types/StackSpecDefaultLbType.yml"}},"oneOf":[{"title":"StackSpecHaProxyLbType","type":"object","required":["type","details","ipv4","ipv6"],"properties":{"ipv4":{"description":"Allow / disallow traffic to be routed via IPv4.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"ipv6":{"description":"Allow / disallow traffic to be routed via IPv6.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"type":{"type":"string","enum":["haproxy"]},"details":{"anyOf":[{"title":"StackSpecHaProxyConfig","type":"object","description":"Describes settings that are passed to HAProxy within the load balancer.","required":["default","ports"],"properties":{"default":{"description":"Settings that are applied to any port that is not overridden in the following ports section.","oneOf":[{"title":"StackSpecHAProxyConfigSet","type":"object","required":["frontend","backend"],"properties":{"frontend":{"oneOf":[{"type":"object","description":"Settings that describe how incoming traffic to the load balancer is handled.","required":["mode","max_connections","timeouts"],"properties":{"mode":{"description":"The type of traffic expected by the load balancer for this port. Can be either: \n - tcp: Traffic is forwarded without any parsing or additional manipulation. \n - http: Traffic is treated as web traffic. If a LINKED record is configured for a container exposing this port, the domain will be parsed and it will be forwarded to the proper container. This allows multiple services to run on port 80 in the same environment.","oneOf":[{"type":"string","enum":["tcp","http"]},{"$ref":"#/properties/about/oneOf/1"}]},"max_connections":{"description":"The number of simultaneous connections that can be processed at a time.","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"timeouts":{"description":"Various options for handling timeouts when communicating with the client.","oneOf":[{"type":["object","null"],"required":["client_secs","client_fin_ms","http_keep_alive_ms","http_request_ms"],"properties":{"client_secs":{"description":"The number of seconds the load balancer will wait for a response from a client before disconnecting.","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"client_fin_ms":{"description":"The number of milliseconds the load balancer will wait for a client to send it data when one direction is already closed. This is particularly useful to avoid keeping connections in a waiting state for too long when clients do not disconnect cleanly.","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"http_keep_alive_ms":{"description":"The number of milliseconds the load balancer will wait for a new HTTP request to start coming after a response was set. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-timeout%20http-request) for more information. (`http` mode only)","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"http_request_ms":{"description":"The number of milliseconds the load balancer will wait for a complete HTTP request. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-timeout%20http-request) for more information. (`http` mode only)","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"backend":{"oneOf":[{"type":"object","description":"Settings related to how the load balancer routes connections to container instances.","required":["balance","timeouts"],"properties":{"balance":{"description":"How connections are balanced across your container instances. Can be one of the following: \n - `roundrobin`: Each container instance is used in turns. \n - `static-rr`: Each container instance is used in turns, but is faster than Round Robin at the expense of being less dynamic. \n - `leastconn`: Routes traffic to the instance with the least number of active connections. \n - `first`: Routes traffic to the first available instance. \n - `source`: The same client IP always reaches the same container instance as long as no instance goes down or up.","oneOf":[{"type":"string","enum":["roundrobin","static-rr","leastconn","first","source"]},{"$ref":"#/properties/about/oneOf/1"}]},"timeouts":{"description":"Various options for handling timeouts when communicating with a container instance behind the load balancer.","oneOf":[{"type":["object","null"],"required":["server_secs","server_fin_ms","connect_ms","queue_ms","tunnel_secs"],"properties":{"server_secs":{"description":"The number of seconds the load balancer will wait for a response from the container instance. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-timeout%20server) for more information.","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"server_fin_ms":{"description":"The number of milliseconds the load balancer will wait for the server to send data when one direction is already closed. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-timeout%20server-fin) for more information.","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"connect_ms":{"description":"The number of milliseconds the load balancer will wait for a successful connection to a container instance. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-timeout%20connect) for more information.","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"queue_ms":{"description":"The number of milliseconds the load balancer will hold connections in a queue when the maximum number of connections has been reached. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-timeout%20queue) for more information.","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"tunnel_secs":{"description":"The number of milliseconds the load balancer will allow for inactivity on a bidirectional tunnel. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-timeout%20tunnel) for more information.","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"ports":{"description":"An object that defines how HAProxy will act on a specific port. The key is a custom port, and the value is the same settings object found under `default` above.","oneOf":[{"type":"object","additionalProperties":{"oneOf":[{"$ref":"#/properties/services/oneOf/0/properties/loadbalancer/anyOf/0/properties/config/anyOf/0/oneOf/0/properties/details/anyOf/0/properties/default/oneOf/0"},{"$ref":"#/properties/about/oneOf/1"}]}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"title":"StackSpecV1LbType","type":"object","required":["type","details","ipv4","ipv6"],"properties":{"ipv4":{"description":"Allow / disallow traffic to be routed via IPv4.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"ipv6":{"description":"Allow / disallow traffic to be routed via IPv6.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"type":{"type":"string","enum":["v1"]},"details":{"oneOf":[{"title":"StackSpecV1LbConfig","type":"object","required":["controllers"],"properties":{"controllers":{"description":"A configuration for a specific port.","oneOf":[{"type":"array","items":{"$ref":"#/properties/services/oneOf/0/properties/loadbalancer/anyOf/0/properties/config/anyOf/0/oneOf/1/properties/details/oneOf/0/properties/controller_template/anyOf/0"}},{"$ref":"#/properties/about/oneOf/1"}]},"controller_template":{"anyOf":[{"title":"StackSpecV1LbController","type":"object","required":["identifier","port"],"properties":{"identifier":{"description":"A human-readable identifier for this controller. It will default to the port, i.e. `port-443`, but can be renamed to anything, such as the service this controller represents.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"port":{"description":"The port inbound trafic is accepted on.","oneOf":[{"type":"integer"},{"$ref":"#/properties/about/oneOf/1"}]},"waf":{"anyOf":[{"$ref":"#/properties/services/oneOf/0/properties/loadbalancer/anyOf/0/properties/config/anyOf/0/oneOf/1/properties/details/oneOf/0/properties/waf/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"transport":{"title":"V1LbControllerTransport","description":"Defines how traffic comes in to the load balancer, and how the load balancer handles it.","oneOf":[{"type":["object","null"],"required":["mode","config","routers","disable"],"properties":{"disable":{"description":"When true, this controller is disabled and will not be used.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"mode":{"description":"The kind of traffic (http/tcp/udp) that will be sent to the load balancer.","oneOf":[{"type":"string","enum":["tcp","udp","http"]},{"$ref":"#/properties/about/oneOf/1"}]},"config":{"description":"Defines how the transport for this controller operates.","oneOf":[{"type":"object","required":["performance","ingress","timeouts","verbosity"],"properties":{"performance":{"description":"Enable/disable performance mode. If enabled, some telemetry will be disabled to dedicate full processing to handling requests.\nYou will not see per-request breakdowns or URL logging if performance mode is enabled.\n","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"ingress":{"description":"Defines how traffic gets into the load balancer.","oneOf":[{"type":"object","properties":{"tls":{"oneOf":[{"type":["object","null"],"required":["enable"],"properties":{"enable":{"description":"Enables or disables TLS.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"timeouts":{"description":"Defines settings for various types of timeouts.","oneOf":[{"type":"object","required":["idle"],"properties":{"idle":{"description":"The total amount of time a connection can be idle before being killed.","oneOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"verbosity":{"description":"Verbosity describes the level of logging detail for the controller","oneOf":[{"type":"string","enum":["low","normal","high","debug"]},{"$ref":"#/properties/about/oneOf/1"}]},"extension":{"description":"Extended configurations for the specified transport mode (http/tcp)","oneOf":[{"type":"object","discriminator":{"propertyName":"type","mapping":{"tcp":"transports/StackSpecTcpTransportConfig.yml","http":"transports/StackSpecHttpTransportConfig.yml","udp":"transports/StackSpecUdpTransportConfig.yml"}},"oneOf":[{"title":"StackSpecTcpTransportConfig","description":"Additional configuration options for the TCP transport mode.","type":"object","required":["type","details"],"properties":{"type":{"type":"string","enum":["tcp"]},"details":{"oneOf":[{"type":"object","required":["connections","telemetry"],"properties":{"connections":{"oneOf":[{"type":"object","additionalProperties":{}},{"$ref":"#/properties/about/oneOf/1"}]},"telemetry":{"description":"Configuration options for how telemetry is handled on the load balancer.","oneOf":[{"type":"object","additionalProperties":{}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"title":"StackSpecHttpTransportConfig","description":"Additional configuration options for the HTTP transport mode.","type":"object","required":["type","details"],"properties":{"type":{"type":"string","enum":["http"]},"details":{"oneOf":[{"type":"object","required":["connections","telemetry"],"properties":{"connections":{"oneOf":[{"type":"object","required":["max_idle_conns_per_connection"],"description":"Defines extra configuration options connections to the load balancer","properties":{"max_idle_conns_per_connection":{"oneOf":[{"type":["integer","null"],"description":"Maximum number of simultaneous connections (via http/2) per connection."},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"telemetry":{"oneOf":[{"type":"object","description":"Configuration options for how telemetry is handled.","properties":{"max_trackable_urls":{"description":"Determines how many URLs the load balancer will track at one time. Defaults to 150.","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"track_invalid_requests":{"description":"Whether or not to track invalid requests. An invalid request is a request that came in that no router existed for. Usually this means bot requests. Defaults to false.","oneOf":[{"type":["boolean","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"ignore_paths":{"description":"An array of paths to exclude from tracking.","oneOf":[{"type":["array","null"],"items":{"type":"string"}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"title":"StackSpecUdpTransportConfig","description":"Additional configuration options for the UDP transport mode.","type":"object","required":["type","details"],"properties":{"type":{"type":"string","enum":["udp"]},"details":{"oneOf":[{"type":"object","required":["telemetry"],"properties":{"telemetry":{"description":"Configuration options for how telemetry is handled on the load balancer.","oneOf":[{"type":"object","additionalProperties":{}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}}]},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"routers":{"description":"Defines where traffic is sent. Many can be defined per controller.","oneOf":[{"type":"array","items":{"oneOf":[{"title":"StackSpecV1LbRouterConfig","description":"A specific router configuration that describes how traffic matching the rule is handled.","type":"object","required":["match","mode","config"],"properties":{"match":{"oneOf":[{"type":"object","description":"The ruleset for this router to be selected. If both `domains`` and `internal_port` are null, then this match acts as a wildcard and will match all.","required":["domains","internal_ports"],"properties":{"domains":{"description":"The specific domains to match against.","oneOf":[{"type":["array","null"],"items":{"type":"string"}},{"$ref":"#/properties/about/oneOf/1"}]},"internal_ports":{"description":"The specific ports to match against.","oneOf":[{"type":["array","null"],"items":{"type":"integer"}},{"$ref":"#/properties/about/oneOf/1"}]},"path":{"oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"containers":{"description":"Match traffic destined (or not destined) for a particular container.","oneOf":[{"type":["object","null"],"properties":{"include":{"description":"Match any traffic that would be routed to one of these containers.","oneOf":[{"type":["array","null"],"items":{"$ref":"#/properties/containers/oneOf/0/additionalProperties/properties/volumes/oneOf/0/items/properties/external/anyOf/0/properties/id/oneOf/0"}},{"$ref":"#/properties/about/oneOf/1"}]},"exclude":{"description":"Match any traffic that would NOT be routed to one of these containers.","oneOf":[{"type":["array","null"],"items":{"$ref":"#/properties/containers/oneOf/0/additionalProperties/properties/volumes/oneOf/0/items/properties/external/anyOf/0/properties/id/oneOf/0"}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"mode":{"description":"How to route the traffic to the destination.\n`random`: Pick a valid destination at random.\n`round-robin`: Send each request to the 'next' destination on the list, restarting from the beginning when the last destination is used.\n`source-ip`: Utilizes a hash function to ensure traffic from an IP will always hit the same destination instance.\n","oneOf":[{"type":"string","enum":["random","round-robin","source-ip"]},{"$ref":"#/properties/about/oneOf/1"}]},"config":{"oneOf":[{"type":"object","required":["sticky_sessions","destination_retries","timeouts"],"properties":{"sticky_sessions":{"description":"If a request comes in from the same origin, ensure it hits the same destination.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"destination_retries":{"description":"If a destination is unavailable, retry up to [x] times, instead of immediately failing with a 503/504 error.","oneOf":[{"type":"integer"},{"$ref":"#/properties/about/oneOf/1"}]},"destination_prioritization":{"oneOf":[{"type":"string","description":"Hints to the load balancer how to prioritize traffic to instances.\n**random**: Chooses a random instance. **latency**: Prioritizes lower latency instances. **fixed**: The order of the destinations will be the same regardless of instance or load balancer location.  Used primarily with source IP routing.\n","enum":["latency","random","fixed"]},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"tls":{"description":"TLS termination configuration. If null, the platform will use the default configuration. Port 443 by default has TLS termination enabled.","oneOf":[{"type":["object","null"],"properties":{"server_name":{"description":"[Advanced] Change the domain the controller listens on.\n","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"allow_insecure":{"description":"If enabled, accept TLS traffic with an invalid certificate. This is usually done for development/testing, and is not recommended for production use.","oneOf":[{"type":["boolean","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"client_cert_auth":{"description":"A PEM encoded string of certificates.","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"client_auth":{"description":"Defines how to validate the connecting TLS certificate.\n`none`: Do not require a TLS certificate to be sent\n`request`: Asks the client to send a TLS certificate, but does not require nor validate it.\n`require`: Requires a certificate be sent for the request to be valid, but does not validate the certificate.\n`require-verify`: Requires both that the client send a certificate, and that the certificate is valid. This is required when using https.\n","oneOf":[{"type":"string","enum":["none","request","require","require-verify"]},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"timeouts":{"description":"Defines how the length of various sorts of timeouts when communicating with the destination.","oneOf":[{"type":"object","required":["destination_connection"],"properties":{"destination_connection":{"description":"The duration the load balancer will wait before timing out while attempting to connect to the destination.","oneOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"extension":{"anyOf":[{"type":"null"},{"type":"object","description":"Additional configuration options specific to the selected mode (tcp/http).","discriminator":{"propertyName":"type","mapping":{"tcp":"routers/StackSpecTcpRouterConfig.yml","udp":"routers/StackSpecUdpRouterConfig.yml","http":"routers/StackSpecHttpRouterConfig.yml"}},"oneOf":[{"title":"StackSpecTcpRouterConfig","description":"Additional configuration options for TCP mode routers","type":"object","required":["type","details"],"properties":{"type":{"type":"string","enum":["tcp"]},"details":{"oneOf":[{"type":"object","additionalProperties":{}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"title":"StackSpecHttpRouterConfig","description":"Additional configuration options for HTTP mode routers.","type":"object","required":["type","details"],"properties":{"type":{"type":"string","enum":["http"]},"details":{"oneOf":[{"type":"object","properties":{"redirect":{"description":"Defines a built-in redirect for HTTP mode routers","oneOf":[{"type":["object","null"],"required":["auto_https_redirect","remove_www"],"properties":{"auto_https_redirect":{"description":"If enabled and a sibling controller exists for port 443, requests will be auto redirected to it. Essentially sets up automatic TLS redirection for this router.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"remove_www":{"description":"If true, any request comes in with \"www\" prefix will be permanently redirected to the same path without www.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"port":{"description":"The port to redirect traffic to.","oneOf":[{"type":["integer","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"scheme":{"description":"The scheme to redirect to. (i.e. `https`)","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"url":{"description":"A specific URL to redirect to.","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"forward":{"oneOf":[{"type":["object","null"],"properties":{"scheme":{"oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"content_mod":{"description":"Allows the load balancer to modify content before it reaches the user.","oneOf":[{"type":["object","null"],"properties":{"replace":{"description":"An array that describes a list of replacement match/value pairs.","oneOf":[{"type":["array","null"],"items":{"oneOf":[{"type":"object","required":["match","value"],"properties":{"match":{"description":"String that will be replaced.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"value":{"description":"Replacement value.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"url":{"description":"The URL to forward the request to.\n\nGiven a path match of `^/example/(.*)$`, a route such as `/example/wow.jpg` would be forwarded as /wow.jpg.\n","examples":["/$$1"],"oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"proxy":{"oneOf":[{"type":["object","null"],"properties":{"domain":{"description":"The domain that this router will proxy.","oneOf":[{"type":["string","null"]},{"$ref":"#/properties/about/oneOf/1"}]},"url":{"description":"The full URL that this router will proxy.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"content_mod":{"description":"Allows the load balancer to modify content before it reaches the user.","oneOf":[{"type":["object","null"],"properties":{"replace":{"description":"An array that describes a list of replacement match/value pairs.","oneOf":[{"type":["array","null"],"items":{"oneOf":[{"type":"object","required":["match","value"],"properties":{"match":{"description":"String that will be replaced.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"value":{"description":"Replacement value.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"caching":{"oneOf":[{"type":["object","null"],"properties":{"files":{"oneOf":[{"type":["array","null"],"items":{"oneOf":[{"type":"object","required":["match","ttl"],"properties":{"match":{"description":"Regex string that describes the files to cache.","examples":["(.*)\\.(js|jpg|css|png|svg)$"],"oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"ttl":{"description":"Time string that describes the time to live.","oneOf":[{"$ref":"#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"title":"StackSpecUdpRouterConfig","description":"Additional configuration options for UDP mode routers","type":"object","required":["type","details"],"properties":{"type":{"type":"string","enum":["udp"]},"details":{"oneOf":[{"type":"object","additionalProperties":{}},{"$ref":"#/properties/about/oneOf/1"}]}}}]}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"waf":{"anyOf":[{"title":"StackSpecWafConfig","type":"object","description":"Additional configuration options for the web application firewall.","required":["rules"],"properties":{"rules":{"oneOf":[{"type":"array","items":{"oneOf":[{"type":"object","required":["description","skip","type","conditions"],"properties":{"description":{"description":"Some information about the rule.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"skip":{"description":"A boolean that indicates if the rule should be active or skipped.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"type":{"description":"A string that describes if the role should allow or deny traffic based on the conditions.","oneOf":[{"type":"string","enum":["allow","deny"]},{"$ref":"#/properties/about/oneOf/1"}]},"expires":{"description":"The expiration date of the WAF config, if present.","oneOf":[{"type":"string","format":"date-time","examples":["2021-01-30T08:30:00Z"]},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"match":{"description":"A string that describes if both attributes need to be true (match all) or if only one of the conditions needs to be true (match any).","oneOf":[{"type":"string","enum":["any","all"]},{"$ref":"#/properties/about/oneOf/1"}]},"conditions":{"description":"An array of the specific conditions for the rule.","oneOf":[{"type":"array","items":{"oneOf":[{"type":"object","required":["type","operator","value"],"properties":{"type":{"description":"A string that describes the match type for the condition.","oneOf":[{"type":"string","enum":["ip-match","geo-match","url-match","method-match","header-match"]},{"$ref":"#/properties/about/oneOf/1"}]},"operator":{"description":"A string that indicates the range of values relative to the value property.","oneOf":[{"type":"string","enum":["==","!=",">","<",">=","<="]},{"$ref":"#/properties/about/oneOf/1"}]},"value":{"description":"The value corresponding to the condition type.","examples":["0.0.0.0/0"],"oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"title":"StackSpecDefaultLbType","type":"object","required":["type","details","ipv4","ipv6"],"properties":{"ipv4":{"type":"boolean","description":"Allow / disallow traffic to be routed via IPv4."},"ipv6":{"type":"boolean","description":"Allow / disallow traffic to be routed via IPv6."},"type":{"type":"string","enum":["default"]},"details":{"oneOf":[{"$ref":"#/properties/services/oneOf/0/properties/loadbalancer/anyOf/0/properties/config/anyOf/0/oneOf/0/properties/details/anyOf/0"},{"$ref":"#/properties/services/oneOf/0/properties/loadbalancer/anyOf/0/properties/config/anyOf/0/oneOf/1/properties/details/oneOf/0"},{"type":"null"}]}}}]},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"scheduler":{"anyOf":[{"title":"StackSpecSchedulerService","description":"Configuration options for the scheduler service.","type":"object","additionalProperties":false,"properties":{"service":{"anyOf":[{"$ref":"#/properties/services/oneOf/0/properties/vpn/anyOf/0/properties/service/anyOf/0"},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"config":{"anyOf":[{"title":"StackSpecSchedulerConfig","description":"Scheduler specific configuration options.","type":["object","null"],"required":["public"],"properties":{"public":{"description":"If true, this scheduler will be accessible over the public internet. It will enable a LINKED record to be pointed to the scheduler container, and inbound requests to trigger function containers.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"access_keys":{"oneOf":[{"type":"array","items":{"title":"StackSpecSchedulerAccessKey","description":"Custom authorization keys for the scheduler service.","type":"object","required":["name","secret"],"properties":{"name":{"description":"The name given to this access key.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"secret":{"description":"The access key secret. This should be submitted with requests to a publicly accessible scheduler service.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"ips":{"description":"Whitelisted IPs that are allowed to make requests to the scheduler service.","oneOf":[{"type":"array","items":{"type":"string"}},{"$ref":"#/properties/about/oneOf/1"}]}}}},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"vpn":{"anyOf":[{"title":"StackSpecVpnService","description":"Configuration options for the VPN service.","type":"object","additionalProperties":false,"properties":{"service":{"anyOf":[{"title":"StackService","description":"Stack spec configuration options common to all environment services. If one of these properties is defined, all must be.","type":"object","properties":{"enable":{"description":"Whether or not this service should be enabled.","type":"boolean"},"high_availability":{"description":"Whether or not Cycle should run multiple instances of this service for high availability.","type":"boolean"},"auto_update":{"description":"Whether or not Cycle should automatically update this service when a new version is released.","type":"boolean"}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]},"config":{"anyOf":[{"title":"StackSpecVpnConfig","description":"VPN specific configuraiton options.","type":"object","required":["auth","allow_internet"],"properties":{"auth":{"oneOf":[{"type":"object","required":["cycle_accounts","vpn_accounts"],"properties":{"webhook":{"description":"The endpoint to hit when attempting to authorize a VPN account. If the endpoint returns a 200 response, access is granted. Otherwise it is denied.","oneOf":[{"type":"string"},{"$ref":"#/properties/about/oneOf/1"}]},"cycle_accounts":{"description":"If true, any account with access to this environment on Cycle can use their Cycle credentials to log in to this VPN.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"vpn_accounts":{"description":"If true, Cycle will allow custom accounts to be created for logging into this VPN.","oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"allow_internet":{"oneOf":[{"type":"boolean"},{"$ref":"#/properties/about/oneOf/1"}]},"custom_directives":{"type":["string","null"],"description":"Additional OpenVPN directives that will be appended to the server configuration on service start. Each line should follow standard OpenVPN syntax.\n","examples":["client-to-client\nduplicate-cn\npersist-key\npersist-tun\n","verb 3\nmute 10\n"]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"$ref":"#/properties/about/oneOf/1"},{"type":"null"}]}}},{"$ref":"#/properties/about/oneOf/1"}]},"annotations":{"description":"Additional meta info about the stack.","oneOf":[{"type":"object","additionalProperties":{}},{"$ref":"#/properties/about/oneOf/1"}]}}}
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "StackSpec",
+  "description": "A Cycle stack file is an \"environment as code\". This allows an environment to be generated consistently based on a fixed specification. \nStack files can describe multiple containers and their configurations, environment service settings, scoped variables, and important metadata.\n",
+  "type": "object",
+  "required": ["version", "containers"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "The version of the Cycle stack file used.",
+      "enum": ["1.0"]
+    },
+    "about": {
+      "oneOf": [
+        {
+          "type": ["object", "null"],
+          "required": ["description", "version"],
+          "properties": {
+            "version": {
+              "type": "string",
+              "description": "A custom, user-defined version of the stack."
+            },
+            "description": {
+              "type": "string",
+              "description": "Custom, user-defined details about this stack."
+            }
+          }
+        },
+        {
+          "title": "StackVariable",
+          "description": "A variable specified in a stack spec.",
+          "pattern": "\\\"?{{(\\$)?([a-z0-9\\-]+)}}\\\"?",
+          "type": "string",
+          "examples": ["{{$stack-variable}}"]
+        }
+      ]
+    },
+    "scoped_variables": {
+      "description": "Describes variables that are assigned to one or more containers at runtime. Can be assigned as an environment variable, written as a file inside the container(s), or accessed over the internal API.",
+      "oneOf": [
+        {
+          "type": ["array", "null"],
+          "items": {
+            "title": "StackSpecScopedVariable",
+            "type": "object",
+            "required": ["identifier", "scope", "access"],
+            "properties": {
+              "identifier": {
+                "oneOf": [
+                  {
+                    "title": "Identifier",
+                    "type": "string",
+                    "description": "A human-readable identifier used to refer to a resource, where using the official ID may be inconvenient.\nThe identifier is automatically tokenized from the name/relevant field of the resource if one is not provided. For example, a container named \"My Container\" will\nhave the identifier of `my-container` and is automatically created by the platform.\n\nThe identifier does not have to be unique.\n"
+                  },
+                  { "$ref": "#/properties/about/oneOf/1" }
+                ]
+              },
+              "scope": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": ["containers"],
+                    "properties": {
+                      "containers": {
+                        "description": "Describes the containers that have access to this scoped variable.",
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "required": ["global"],
+                            "properties": {
+                              "global": {
+                                "description": "If true, all containers in the environment will have access to this variable.",
+                                "oneOf": [
+                                  { "type": "boolean" },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "ids": {
+                                "description": "A list of container IDs that are granted access to this variable.",
+                                "oneOf": [
+                                  {
+                                    "type": ["array", "null"],
+                                    "items": { "type": "string" }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "identifiers": {
+                                "description": "A list of container identifiers that are granted access to this variable.",
+                                "oneOf": [
+                                  {
+                                    "type": ["array", "null"],
+                                    "items": {
+                                      "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/identifier/oneOf/0"
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              }
+                            }
+                          },
+                          { "$ref": "#/properties/about/oneOf/1" }
+                        ]
+                      }
+                    }
+                  },
+                  { "$ref": "#/properties/about/oneOf/1" }
+                ]
+              },
+              "access": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "env_variable": {
+                        "description": "Grants access to this variable from within a container as an environment variable.",
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "required": ["key"],
+                            "properties": {
+                              "key": {
+                                "description": "The environment variable inside the container that stores the value of the variable.",
+                                "oneOf": [
+                                  { "type": "string" },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              }
+                            }
+                          },
+                          { "$ref": "#/properties/about/oneOf/1" },
+                          { "type": "null" }
+                        ]
+                      },
+                      "internal_api": {
+                        "description": "Grants access to this variable over the Internal API.",
+                        "oneOf": [
+                          {
+                            "type": ["object", "null"],
+                            "properties": {
+                              "duration": {
+                                "description": "Sets the duration that this variable can be accessed over the Internal API, after container start. Provides additional security as sensitive data can only be accessed for a limited time.",
+                                "anyOf": [
+                                  {
+                                    "title": "Duration",
+                                    "type": "string",
+                                    "description": "A string signifying a duration of time. Valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\", \"d\", \"w\", \"y\".",
+                                    "examples": ["72h45m2s"]
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" },
+                                  { "type": "null" }
+                                ]
+                              }
+                            }
+                          },
+                          { "$ref": "#/properties/about/oneOf/1" }
+                        ]
+                      },
+                      "file": {
+                        "description": "Grants access to this variable as a file inside the container.",
+                        "oneOf": [
+                          {
+                            "type": ["object", "null"],
+                            "required": ["decode", "path"],
+                            "properties": {
+                              "decode": {
+                                "description": "When true, Cycle will interpret this variable as a base-64 encoded string, and decode it before writing it to the file inside the container.",
+                                "oneOf": [
+                                  { "type": "boolean" },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "path": {
+                                "description": "The absolute path to write the variable to (including file name). If `null`, it will be written to `/var/run/cycle/variables/{variable-identifier}`.",
+                                "oneOf": [
+                                  { "type": ["string", "null"] },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ],
+                                "examples": [
+                                  "/var/run/cycle/variables/<myVariable>"
+                                ]
+                              },
+                              "permissions": {
+                                "oneOf": [
+                                  { "type": ["string", "null"] },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ],
+                                "description": "A linux file mode that will be set on the injected file.",
+                                "examples": ["0644"]
+                              },
+                              "uid": {
+                                "oneOf": [
+                                  { "type": ["integer", "null"] },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ],
+                                "description": "The linux UID to set on the file.",
+                                "examples": [777]
+                              },
+                              "gid": {
+                                "oneOf": [
+                                  { "type": ["integer", "null"] },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ],
+                                "description": "The linux GID to set on the file.",
+                                "examples": [777]
+                              }
+                            }
+                          },
+                          { "$ref": "#/properties/about/oneOf/1" }
+                        ]
+                      }
+                    }
+                  },
+                  { "$ref": "#/properties/about/oneOf/1" }
+                ]
+              },
+              "source": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "description": "Describes the source/value of the variable.\n- **raw**: Directly set the value of the variable in the stack. - **url**: Cycle will fetch the variable content from a remote source when the container starts.\n",
+                    "discriminator": {
+                      "propertyName": "type",
+                      "mapping": {
+                        "url": "./StackSpecScopedVariableUrlSource.yml",
+                        "raw": "./StackSpecScopedVariableRawSource.yml"
+                      }
+                    },
+                    "oneOf": [
+                      {
+                        "title": "StackSpecScopedVariableUrlSource",
+                        "type": "object",
+                        "description": "A variable who's value is fetched from a URL when the container starts.",
+                        "required": ["type", "details"],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The type of scoped variable.",
+                            "enum": ["url"]
+                          },
+                          "details": {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "required": [
+                                  "url",
+                                  "headers",
+                                  "auth_token_url"
+                                ],
+                                "properties": {
+                                  "url": {
+                                    "description": "The URL to call to fetch the value.",
+                                    "oneOf": [
+                                      { "type": "string" },
+                                      { "$ref": "#/properties/about/oneOf/1" }
+                                    ]
+                                  },
+                                  "headers": {
+                                    "description": "Additional headers that can be attached to the URL request. Useful for adding meta-data to third-party services.",
+                                    "oneOf": [
+                                      {
+                                        "type": "object",
+                                        "additionalProperties": {}
+                                      },
+                                      { "$ref": "#/properties/about/oneOf/1" }
+                                    ]
+                                  },
+                                  "auth_token_url": {
+                                    "description": "A URL that can be provided to authenticate with a third party secret service. Cycle will make a request to this URL before fetching the secret URL, and use the response as the value of an Authorization header when requesting the secret.",
+                                    "oneOf": [
+                                      { "type": ["string", "null"] },
+                                      { "$ref": "#/properties/about/oneOf/1" }
+                                    ]
+                                  }
+                                }
+                              },
+                              { "$ref": "#/properties/about/oneOf/1" }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "title": "StackSpecScopedVariableRawSource",
+                        "type": "object",
+                        "description": "A variable with a hard-coded value.",
+                        "required": ["type", "details"],
+                        "properties": {
+                          "type": {
+                            "description": "The type of scoped variable.",
+                            "type": "string",
+                            "enum": ["raw"]
+                          },
+                          "details": {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "required": ["value", "blob"],
+                                "properties": {
+                                  "value": {
+                                    "description": "The value of the variable.",
+                                    "oneOf": [
+                                      { "type": "string" },
+                                      { "$ref": "#/properties/about/oneOf/1" }
+                                    ]
+                                  },
+                                  "blob": {
+                                    "description": "A boolean where true represents the text the user is entering will be multi line.",
+                                    "oneOf": [
+                                      { "type": "boolean" },
+                                      { "$ref": "#/properties/about/oneOf/1" }
+                                    ]
+                                  },
+                                  "secret": {
+                                    "oneOf": [
+                                      {
+                                        "type": ["object", "null"],
+                                        "properties": {
+                                          "iv": {
+                                            "description": "A string describing the IV Hex associated with the encryption of the variable.",
+                                            "oneOf": [
+                                              { "type": "string" },
+                                              {
+                                                "$ref": "#/properties/about/oneOf/1"
+                                              }
+                                            ]
+                                          },
+                                          "hint": {
+                                            "description": "A user specified hint that will suggest what the encryption key might be",
+                                            "oneOf": [
+                                              { "type": "string" },
+                                              {
+                                                "$ref": "#/properties/about/oneOf/1"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      { "$ref": "#/properties/about/oneOf/1" }
+                                    ]
+                                  }
+                                }
+                              },
+                              { "$ref": "#/properties/about/oneOf/1" }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  { "$ref": "#/properties/about/oneOf/1" },
+                  { "type": "null" }
+                ]
+              }
+            }
+          }
+        },
+        { "$ref": "#/properties/about/oneOf/1" }
+      ]
+    },
+    "containers": {
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "A mapping of containers that will be deployed as a part of this stack. The key is used as the container's identifier.",
+          "additionalProperties": {
+            "title": "StackSpecContainer",
+            "description": "A container template defined within a stack.",
+            "type": "object",
+            "required": ["name", "image", "config", "stateful"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The human-readable name of this container."
+              },
+              "image": {
+                "x-ogen-name": "StackSpecContainerImageProperty",
+                "description": "Details about the image used for this container.",
+                "oneOf": [
+                  {
+                    "title": "StackSpecContainerImage",
+                    "type": "object",
+                    "required": ["origin"],
+                    "properties": {
+                      "name": {
+                        "description": "The human-readable name of this image.",
+                        "oneOf": [
+                          { "type": ["string", "null"] },
+                          { "$ref": "#/properties/about/oneOf/1" }
+                        ]
+                      },
+                      "origin": {
+                        "description": "Instructions on how to fetch or build this image.",
+                        "oneOf": [
+                          {
+                            "title": "StackSpecImageOrigin",
+                            "type": "object",
+                            "description": "The origin of the image.",
+                            "discriminator": {
+                              "propertyName": "type",
+                              "mapping": {
+                                "docker-hub": "../../components/schemas/images/origins/dockerHub/DockerHubOrigin.yml",
+                                "docker-file": "../../components/schemas/images/origins/dockerFile/DockerFileOrigin.yml",
+                                "docker-registry": "../../components/schemas/images/origins/dockerRegistry/DockerRegistryOrigin.yml",
+                                "oci-registry": "../../components/schemas/images/origins/ociRegistry/OciRegistryOrigin.yml",
+                                "cycle-source": "../../components/schemas/images/origins/cycleSource/CycleSourceOrigin.yml"
+                              }
+                            },
+                            "oneOf": [
+                              {
+                                "title": "DockerHubOrigin",
+                                "type": "object",
+                                "description": "An image origin where the image is pulled from DockerHub.",
+                                "required": ["type", "details"],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": ["docker-hub"]
+                                  },
+                                  "details": {
+                                    "type": "object",
+                                    "required": ["target"],
+                                    "properties": {
+                                      "existing": {
+                                        "anyOf": [
+                                          {
+                                            "$ref": "#/properties/containers/oneOf/0/additionalProperties/properties/image/oneOf/0/properties/origin/oneOf/0/oneOf/2/properties/details/properties/existing"
+                                          },
+                                          { "type": "null" }
+                                        ]
+                                      },
+                                      "target": {
+                                        "type": "string",
+                                        "description": "The DockerHub target string. ex - `mysql:5.7`"
+                                      },
+                                      "username": {
+                                        "type": "string",
+                                        "description": "For authentication, a username."
+                                      },
+                                      "token": {
+                                        "type": "string",
+                                        "description": "For authentication, a token."
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "title": "DockerFileOrigin",
+                                "type": "object",
+                                "description": "An image origin where the image is built from a Dockerfile located in a git repository.",
+                                "required": ["type", "details"],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": ["docker-file"]
+                                  },
+                                  "details": {
+                                    "type": "object",
+                                    "properties": {
+                                      "existing": {
+                                        "anyOf": [
+                                          {
+                                            "$ref": "#/properties/containers/oneOf/0/additionalProperties/properties/image/oneOf/0/properties/origin/oneOf/0/oneOf/2/properties/details/properties/existing"
+                                          },
+                                          { "type": "null" }
+                                        ]
+                                      },
+                                      "repo": {
+                                        "anyOf": [
+                                          {
+                                            "title": "RepoSourceType",
+                                            "type": "object",
+                                            "description": "Information about the repository.",
+                                            "required": ["url"],
+                                            "properties": {
+                                              "url": {
+                                                "type": "string",
+                                                "description": "The URL of the repository."
+                                              },
+                                              "branch": {
+                                                "type": "string",
+                                                "description": "An optional branch arguement.  Default value is `master`."
+                                              },
+                                              "auth": {
+                                                "anyOf": [
+                                                  { "type": "null" },
+                                                  {
+                                                    "type": "object",
+                                                    "description": "Authentication information for the repository.",
+                                                    "discriminator": {
+                                                      "propertyName": "type",
+                                                      "mapping": {
+                                                        "http": "../CredentialsHTTP.yml",
+                                                        "ssh": "../CredentialsSSH.yml"
+                                                      }
+                                                    },
+                                                    "oneOf": [
+                                                      {
+                                                        "title": "HTTPSourceCredentials",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "type",
+                                                          "credentials"
+                                                        ],
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": ["http"]
+                                                          },
+                                                          "credentials": {
+                                                            "type": "object",
+                                                            "description": "Authentication credentails for the Dockerfile image source type when authenticating over HTTP.",
+                                                            "required": [
+                                                              "username",
+                                                              "password"
+                                                            ],
+                                                            "properties": {
+                                                              "username": {
+                                                                "type": "string",
+                                                                "description": "For authentication, the username."
+                                                              },
+                                                              "password": {
+                                                                "type": "string",
+                                                                "description": "For authentication, the password."
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "title": "SSHSourceCredentials",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "type",
+                                                          "credentials"
+                                                        ],
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": ["ssh"]
+                                                          },
+                                                          "credentials": {
+                                                            "type": "object",
+                                                            "description": "Authentication credentials for the Dockerfile image source type when authenticating with SSH.",
+                                                            "required": [
+                                                              "username",
+                                                              "passphrase",
+                                                              "private_key"
+                                                            ],
+                                                            "properties": {
+                                                              "username": {
+                                                                "type": "string",
+                                                                "description": "The username for the repo service, that is used to authenticate an ssh key."
+                                                              },
+                                                              "passphrase": {
+                                                                "type": "string",
+                                                                "description": "The passphrase used for the key."
+                                                              },
+                                                              "private_key": {
+                                                                "type": "string",
+                                                                "description": "A pem encoded private key."
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              "ref": {
+                                                "oneOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "description": "Repository reference information.",
+                                                    "required": [
+                                                      "type",
+                                                      "value"
+                                                    ],
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "description": "The type of reference being used."
+                                                      },
+                                                      "value": {
+                                                        "type": "string",
+                                                        "description": "The value for the given reference type."
+                                                      }
+                                                    }
+                                                  },
+                                                  { "type": "null" }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          { "type": "null" }
+                                        ]
+                                      },
+                                      "targz_url": {
+                                        "type": ["string", "null"],
+                                        "description": "An endpoint that serves the tar file."
+                                      },
+                                      "context_dir": {
+                                        "type": ["string", "null"],
+                                        "description": "The path to the directory to use as the context when building the image."
+                                      },
+                                      "build_file": {
+                                        "type": ["string", "null"],
+                                        "description": "The path to the Dockerfile to be used for buiding the image."
+                                      },
+                                      "credentials": {
+                                        "anyOf": [
+                                          {
+                                            "title": "DockerfileCredentails",
+                                            "description": "An array of credentials objects to be used when authenticating against private images used by the Dockerfile.",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "description": "Credentials object used for authentication of indirect resources such as private parent images.",
+                                              "properties": {
+                                                "url": {
+                                                  "type": "string",
+                                                  "description": "The url the resource is located at."
+                                                },
+                                                "username": {
+                                                  "type": "string",
+                                                  "description": "A username for authentication."
+                                                },
+                                                "token": {
+                                                  "type": "string",
+                                                  "description": "A token for authentication."
+                                                }
+                                              }
+                                            }
+                                          },
+                                          { "type": "null" }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "title": "DockerRegistryOrigin",
+                                "type": "object",
+                                "description": "An image origin where the image is pulled from a private Docker registry.",
+                                "required": ["type", "details"],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": ["docker-registry"]
+                                  },
+                                  "details": {
+                                    "type": "object",
+                                    "required": ["target", "url"],
+                                    "properties": {
+                                      "existing": {
+                                        "title": "ExistingSource",
+                                        "type": "object",
+                                        "description": "In a stack, specifies an image source ID from which Cycle will derive any values not specified in the stack file. This is useful for avoiding direct placement of credentials in a stack file, for example.",
+                                        "properties": {
+                                          "source_id": {
+                                            "$ref": "#/properties/containers/oneOf/0/additionalProperties/properties/image/oneOf/0/properties/origin/oneOf/0/oneOf/4/properties/details/properties/source_id",
+                                            "description": "The ID of the image source this image should be built from."
+                                          }
+                                        }
+                                      },
+                                      "target": {
+                                        "type": "string",
+                                        "description": "The image name on the registry."
+                                      },
+                                      "url": {
+                                        "type": "string",
+                                        "description": "The url of the remote registry."
+                                      },
+                                      "username": {
+                                        "type": "string",
+                                        "description": "For authentication, a username."
+                                      },
+                                      "token": {
+                                        "type": "string",
+                                        "description": "For authentication, a token."
+                                      },
+                                      "password": {
+                                        "type": "string",
+                                        "description": "For authentication, a password."
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "title": "OciRegistryOrigin",
+                                "type": "object",
+                                "description": "An image origin that pulls images fro an OCI-compatible registry. Also used for provider-native registries, such as AWS ECR.",
+                                "required": ["type", "details"],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": ["oci-registry"]
+                                  },
+                                  "details": {
+                                    "type": "object",
+                                    "required": ["target", "url"],
+                                    "properties": {
+                                      "existing": {
+                                        "$ref": "#/properties/containers/oneOf/0/additionalProperties/properties/image/oneOf/0/properties/origin/oneOf/0/oneOf/2/properties/details/properties/existing"
+                                      },
+                                      "target": {
+                                        "type": "string",
+                                        "description": "The image name on the registry."
+                                      },
+                                      "url": {
+                                        "type": "string",
+                                        "description": "The url of the remote registry."
+                                      },
+                                      "auth": {
+                                        "oneOf": [
+                                          {
+                                            "title": "RegistryAuth",
+                                            "type": "object",
+                                            "description": "Authentication details for a third party image registry/source.",
+                                            "discriminator": {
+                                              "propertyName": "type",
+                                              "mapping": {
+                                                "user": "RegistryAuthUser.yml",
+                                                "provider": "RegistryAuthProvider.yml",
+                                                "webhook": "RegistryAuthWebhook.yml"
+                                              }
+                                            },
+                                            "oneOf": [
+                                              {
+                                                "title": "RegistryAuthUser",
+                                                "description": "User/token based credentials for authentication to a third-party image source.",
+                                                "type": "object",
+                                                "required": ["type", "details"],
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": ["user"]
+                                                  },
+                                                  "details": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "username": {
+                                                        "type": "string"
+                                                      },
+                                                      "token": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "title": "RegistryAuthProvider",
+                                                "description": "Credentials for authentication to a provider-native image registry, such as AWS ECR.",
+                                                "type": "object",
+                                                "required": ["type", "details"],
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": ["provider"]
+                                                  },
+                                                  "details": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "flavor",
+                                                      "credentials"
+                                                    ],
+                                                    "properties": {
+                                                      "flavor": {
+                                                        "type": "string",
+                                                        "enum": ["ecr"]
+                                                      },
+                                                      "credentials": {
+                                                        "title": "RegistryAuthProviderCredentials",
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "region": {
+                                                            "type": "string"
+                                                          },
+                                                          "namespace": {
+                                                            "type": "string"
+                                                          },
+                                                          "api_key": {
+                                                            "type": "string"
+                                                          },
+                                                          "secret": {
+                                                            "type": "string"
+                                                          },
+                                                          "subscription_id": {
+                                                            "type": "string"
+                                                          },
+                                                          "client_id": {
+                                                            "type": "string"
+                                                          },
+                                                          "config": {
+                                                            "type": "string",
+                                                            "description": "A base64'd string of additional configuration options."
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "title": "RegistryAuthWebhook",
+                                                "description": "Webhook-based authentication to the provided URL. This webhook expects to receive a base-64 string that when decoded is in the format `username:password`",
+                                                "type": "object",
+                                                "required": ["type", "details"],
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": ["webhook"]
+                                                  },
+                                                  "details": {
+                                                    "type": "object",
+                                                    "required": ["url"],
+                                                    "properties": {
+                                                      "url": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          { "type": "null" }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "title": "CycleSourceOrigin",
+                                "type": "object",
+                                "description": "An image origin that references an image source on Cycle. \n\nThis origin will never be embedded in an image source. It is for use in stacks, describing an image which is already a part of an image source on Cycle.\n",
+                                "required": ["type", "details"],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": ["cycle-source"]
+                                  },
+                                  "details": {
+                                    "type": "object",
+                                    "required": ["source_id"],
+                                    "properties": {
+                                      "source_id": {
+                                        "description": "The ID referencing the image source where this image originated.",
+                                        "title": "ID",
+                                        "type": "string",
+                                        "format": "objectid",
+                                        "examples": ["651586fca6078e98982dbd90"]
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          },
+                          { "$ref": "#/properties/about/oneOf/1" }
+                        ]
+                      },
+                      "build": {
+                        "description": "Additional details applied when building an image.",
+                        "oneOf": [
+                          {
+                            "type": ["object", "null"],
+                            "properties": {
+                              "use_disk": {
+                                "type": "boolean",
+                                "description": "If true, will skip using /dev/shm when building an image on factory, which is limited to `6.5GB`. Allows for building much larger images, up to `20GB`.",
+                                "default": false
+                              },
+                              "args": {
+                                "description": "A map of build arguments applied to the image at build time.",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": { "type": "string" }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              }
+                            }
+                          },
+                          { "$ref": "#/properties/about/oneOf/1" }
+                        ]
+                      },
+                      "builder": {
+                        "description": "A specific builder to use. By default, Cycle uses its factory service and a standard build command to build images, but this can be enhanced by using an image builder integration.",
+                        "oneOf": [
+                          {
+                            "type": ["object", "null"],
+                            "required": ["integration_id"],
+                            "properties": {
+                              "integration_id": {
+                                "description": "The ID of the integration to use when building the image. The integration must support image building to be compatible.",
+                                "$ref": "#/properties/containers/oneOf/0/additionalProperties/properties/volumes/oneOf/0/items/properties/external/anyOf/0/properties/id/oneOf/0"
+                              }
+                            }
+                          },
+                          { "$ref": "#/properties/about/oneOf/1" }
+                        ]
+                      }
+                    }
+                  },
+                  { "$ref": "#/properties/about/oneOf/1" }
+                ]
+              },
+              "annotations": {
+                "oneOf": [
+                  {
+                    "type": ["object", "null"],
+                    "description": "Additional user-provided meta data about the container.",
+                    "additionalProperties": {}
+                  },
+                  { "$ref": "#/properties/about/oneOf/1" }
+                ]
+              },
+              "stateful": {
+                "description": "Whether or not to mark the container as stateful when deployed. Stateful containers can utilize volumes (stateful data) and are generally used for running databases or other data management applications.",
+                "oneOf": [
+                  { "type": "boolean" },
+                  { "$ref": "#/properties/about/oneOf/1" }
+                ]
+              },
+              "config": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "description": "Configuration options for this container that will be applied when deployed as part of the stack.",
+                    "title": "StackContainerConfig",
+                    "required": ["network", "deploy"],
+                    "properties": {
+                      "network": {
+                        "oneOf": [
+                          {
+                            "title": "StackSpecContainerConfigNetwork",
+                            "x-ogen-name": "StackSpecContainerConfigNetwork",
+                            "description": "Stack configuration options related to the container's network.",
+                            "type": "object",
+                            "required": ["public", "hostname"],
+                            "properties": {
+                              "public": {
+                                "description": "The level of public network access this container should have.",
+                                "oneOf": [
+                                  {
+                                    "type": "string",
+                                    "enum": ["enable", "disable", "egress-only"]
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "hostname": {
+                                "description": "The hostname of the container. This is how it can be referenced by other containers in the same environment.",
+                                "oneOf": [
+                                  { "type": "string" },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "ports": {
+                                "description": "A list of port mappings on this container.",
+                                "oneOf": [
+                                  {
+                                    "type": "array",
+                                    "items": { "type": "string" },
+                                    "examples": ["80:80", "443:80", "3000"]
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              }
+                            }
+                          },
+                          { "$ref": "#/properties/about/oneOf/1" }
+                        ]
+                      },
+                      "deploy": {
+                        "oneOf": [
+                          {
+                            "title": "StackSpecContainerConfigDeploy",
+                            "type": "object",
+                            "description": "Stack configuration options related to how the container behaves over its lifecycle (startup, shutdown, health checks, etc).",
+                            "required": ["instances"],
+                            "properties": {
+                              "instances": {
+                                "description": "The number of desired instances to deploy.",
+                                "oneOf": [
+                                  { "type": "integer" },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "strategy": {
+                                "description": "The strategy Cycle will apply when deploying instances of this container.\n\n- ** resource-density **: Cycle will distribute instances across servers to maintain balanced resource usage.\n- ** high-availability **: Cycle will deploy instances across servers with an emphasis on geographic and physical separation. Requires multiple locations.\n- ** distributed **: Cycle will deploy instances across servers with an emphasis on physical separation. Does not require multiple locations.\n- ** first-available **: Cycle will deploy one instance to every server that matches the specified criteria. (default)\n- ** node **: Cycle will deploy one instance to every server that matches the specified criteria.\n- ** edge **: Cycle will prioritize geographic distribution of instances.\n- ** function **: Every ingress request/connection receives its own instance. \n- ** manual **: Cycle will not make any decisions on where instances are deployed. Instead, instances must be deployed manually using the portal or API.\n",
+                                "oneOf": [
+                                  {
+                                    "type": ["string", "null"],
+                                    "enum": [
+                                      "resource-density",
+                                      "manual",
+                                      "high-availability",
+                                      "first-available",
+                                      "node",
+                                      "edge",
+                                      "function"
+                                    ],
+                                    "default": "first-available"
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "function": {
+                                "description": "Configuration options for containers using the 'function' deployment strategy.",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                      "max_pool_size": {
+                                        "description": "The maximum number of instances that Cycle can pre-allocate (includes auto-scaled instances).",
+                                        "oneOf": [
+                                          { "type": ["integer", "null"] },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "max_shard_concurrency": {
+                                        "description": "For each shard (scheduler), the maximum number of tasks it can run in parallel.",
+                                        "oneOf": [
+                                          { "type": ["integer", "null"] },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "max_runtime": {
+                                        "description": "The maximum amount of time a function instance can run before timing out.",
+                                        "anyOf": [
+                                          {
+                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          },
+                                          { "type": "null" }
+                                        ]
+                                      },
+                                      "max_queue_time": {
+                                        "description": "The maximum amount of time Cycle will wait for an instance to be available.",
+                                        "anyOf": [
+                                          {
+                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          },
+                                          { "type": "null" }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "stateful": {
+                                "description": "Configuration options for stateful containers.",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "required": ["options"],
+                                    "properties": {
+                                      "options": {
+                                        "description": "Stateful container options.",
+                                        "type": ["object", "null"],
+                                        "properties": {
+                                          "use_base_hostname": {
+                                            "description": "When enabled, instances will utilize stateless base hostnames instead of being prefixed with a unique ID.",
+                                            "type": ["boolean", "null"]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "constraints": {
+                                "description": "Configuration options that provide the ability to set restrictions on which nodes instances of this container are able to be deployed to. (i.e. if you have a GPU container, it should only go on nodes with a GPU).",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                      "node": {
+                                        "type": ["object", "null"],
+                                        "required": ["tags"],
+                                        "properties": {
+                                          "tags": {
+                                            "description": "Tags applied to a node. Cycle generates some automatically, but additional, custom tags can be applied on a per-node basis.",
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "any": {
+                                                    "description": "If a node has at least one of these tags, it is considered a valid deployment target for this container.",
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "$ref": "#/properties/about/oneOf/1"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "all": {
+                                                    "description": "A node must have **ALL** of these tags to be considered a valid deployment target for this container.",
+                                                    "oneOf": [
+                                                      {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "$ref": "#/properties/about/oneOf/1"
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "$ref": "#/properties/about/oneOf/1"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "shutdown": {
+                                "description": "Configuration options for how this container behaves during shutdown.",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                      "graceful_timeout": {
+                                        "description": "How long the platform will wait for a container to stop gracefully.",
+                                        "anyOf": [
+                                          {
+                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          },
+                                          { "type": "null" }
+                                        ]
+                                      },
+                                      "signals": {
+                                        "oneOf": [
+                                          {
+                                            "type": "array",
+                                            "description": "Signals that should be sent to the container on shutdown.",
+                                            "items": {
+                                              "title": "ShutdownSignal",
+                                              "type": "string",
+                                              "description": "Process signals that Cycle can be configured to send to the container on a shutdown event.",
+                                              "enum": [
+                                                "SIGTERM",
+                                                "SIGINT",
+                                                "SIGUSR1",
+                                                "SIGUSR2",
+                                                "SIGHUP",
+                                                "SIGQUIT"
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "startup": {
+                                "description": "Configuration options for how this container behaves during startup.",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                      "delay": {
+                                        "description": "How long the platform will wait before sending the start signal to the given container.",
+                                        "anyOf": [
+                                          {
+                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          },
+                                          { "type": "null" }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "update": {
+                                "description": "Configurations for how the container behaves during updates.",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                      "stagger": {
+                                        "anyOf": [
+                                          {
+                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          },
+                                          { "type": "null" }
+                                        ],
+                                        "description": "When set, Cycle will pick a random time from `0 - this duration`, and stagger the instances so they all start at different times (up to the time specified here)."
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "restart": {
+                                "description": "Configuration options for how Cycle should handle restarting this container (i.e. in case the process inside the container dies).",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "required": [
+                                      "condition",
+                                      "delay",
+                                      "max_attempts"
+                                    ],
+                                    "properties": {
+                                      "condition": {
+                                        "description": "Under what circumstances Cycle should try to restart this container.",
+                                        "oneOf": [
+                                          {
+                                            "type": "string",
+                                            "enum": [
+                                              "always",
+                                              "never",
+                                              "failure"
+                                            ]
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "delay": {
+                                        "description": "How long the platform will wait between restart attempts.",
+                                        "oneOf": [
+                                          {
+                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "max_attempts": {
+                                        "description": "The maximum number of restart attempts Cycle will make.",
+                                        "oneOf": [
+                                          { "type": "integer" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "health_check": {
+                                "description": "Configuration options for automated container health checks.",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "required": [
+                                      "command",
+                                      "retries",
+                                      "interval",
+                                      "timeout",
+                                      "restart"
+                                    ],
+                                    "properties": {
+                                      "command": {
+                                        "description": "The command or script to run to verify the health of the container. This script is run inside the container by Cycle.\nThis command accepts two types of entries:\n- The first is a reference to a script that already lives in the container filesystem. This can be defined by giving the full path to the script as the value.   - The second format is an inline script.  If you need the code to execute within a shell, wrap the commands in escaped quotes like this `\"\\\"curl -s -o /dev/console -w \\\"%{http_code}\\\" http://localhost:3000/_health | grep '200'  && exit 0 || exit 1\\\"\"`.  Do not use the `/bin/sh -c <commands>` format, this will not be accepted.\n",
+                                        "oneOf": [
+                                          {
+                                            "type": "string",
+                                            "examples": [
+                                              "/bin/sh healthcheck.sh"
+                                            ]
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "retries": {
+                                        "description": "The number of times to retry the command before marking an instance unhealthy.",
+                                        "oneOf": [
+                                          { "type": "integer" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "interval": {
+                                        "description": "How long to wait between running health checks.",
+                                        "oneOf": [
+                                          {
+                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "timeout": {
+                                        "description": "How long before a health check attempt times out.",
+                                        "oneOf": [
+                                          {
+                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "restart": {
+                                        "description": "A boolean where true represents the desire for the container to restart if any instance is unhealthy.",
+                                        "oneOf": [
+                                          { "type": "boolean" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "delay": {
+                                        "anyOf": [
+                                          {
+                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          },
+                                          { "type": "null" }
+                                        ],
+                                        "description": "How long to wait after a container start event before running health checks."
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "telemetry": {
+                                "description": "Configuration options for how the instance telemetry (CPU usage, etc) is handled.",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "required": ["disable"],
+                                    "properties": {
+                                      "retention": {
+                                        "anyOf": [
+                                          {
+                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          },
+                                          { "type": "null" }
+                                        ],
+                                        "description": "How long telemetry data should be retained."
+                                      },
+                                      "interval": {
+                                        "anyOf": [
+                                          {
+                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          },
+                                          { "type": "null" }
+                                        ],
+                                        "description": "The duration between samples."
+                                      },
+                                      "webhook": {
+                                        "description": "A URL where Cycle will send telemetry data to. The payload will be an instance resource snapshot.",
+                                        "oneOf": [
+                                          { "type": ["string", "null"] },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "disable": {
+                                        "description": "If true, Cycle will not aggregate telemetry for this container's instances.",
+                                        "oneOf": [
+                                          { "type": "boolean" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              }
+                            }
+                          },
+                          { "$ref": "#/properties/about/oneOf/1" }
+                        ]
+                      },
+                      "scaling": {
+                        "description": "Configuration options for auto-scaling.",
+                        "anyOf": [
+                          {
+                            "title": "StackSpecContainerConfigScaling",
+                            "type": "object",
+                            "description": "Stack configuration options for auto-scaling.",
+                            "required": [
+                              "autoscale_group",
+                              "instances",
+                              "window",
+                              "thresholds"
+                            ],
+                            "properties": {
+                              "autoscale_group": {
+                                "anyOf": [
+                                  {
+                                    "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/identifier/oneOf/0"
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" },
+                                  { "type": "null" }
+                                ],
+                                "description": "The identifier of the auto-scaling group assigned to this container. The auto-scale group determines which infrastructure this container can spin up if it needs more resources to meet demand. Setting it to `null` will limit auto-scaling to only instances."
+                              },
+                              "instances": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "description": "Describes the criteria for deploying new instances when an auto-scale criteria is met.",
+                                    "required": [
+                                      "max",
+                                      "max_server",
+                                      "min_ttl"
+                                    ],
+                                    "properties": {
+                                      "max": {
+                                        "description": "Maximum additional instances the auto-scaler will run at any time.",
+                                        "oneOf": [
+                                          { "type": "integer" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "max_server": {
+                                        "description": "Minimum number of instances per server.",
+                                        "oneOf": [
+                                          { "type": "integer" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "min_ttl": {
+                                        "description": "Minimum amount of time an instance will live.",
+                                        "oneOf": [
+                                          {
+                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "window": {
+                                "description": "Duration in which the auto-scaler will watch for changes.",
+                                "oneOf": [
+                                  {
+                                    "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "thresholds": {
+                                "description": "An array of rules that dictate when a scaling event will be triggered.",
+                                "oneOf": [
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "title": "StackSpecContainerScaleThreshold",
+                                      "type": "object",
+                                      "description": "Discriminated union describing the different types of scaling threshold and their respective details",
+                                      "discriminator": {
+                                        "propertyName": "type",
+                                        "mapping": {
+                                          "ram": "./StackSpecContainerScaleThresholdRam.yml",
+                                          "cpu": "./StackSpecContainerScaleThresholdCpu.yml",
+                                          "custom": "./StackSpecContainerScaleThresholdCustom.yml",
+                                          "network-connections": "./StackSpecContainerScaleThresholdNetworkConnections.yml",
+                                          "network-requests": "./StackSpecContainerScaleThresholdNetworkRequests.yml",
+                                          "network-throughput": "./StackSpecContainerScaleThresholdNetworkThroughput.yml"
+                                        }
+                                      },
+                                      "oneOf": [
+                                        {
+                                          "title": "StackSpecContainerScaleThresholdRam",
+                                          "type": "object",
+                                          "description": "Describes the RAM threshold at which scaling will occur.",
+                                          "required": ["type", "details"],
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": ["ram"]
+                                            },
+                                            "details": {
+                                              "type": "object",
+                                              "required": ["usage"],
+                                              "properties": {
+                                                "usage": {
+                                                  "type": "string",
+                                                  "description": "The target average RAM usage of all instances of this container. Going above this threshold will trigger a scaling event. This threshold must be greater than 25MB.",
+                                                  "examples": ["2G", "25MB"]
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "title": "StackSpecContainerScaleThresholdCpu",
+                                          "type": "object",
+                                          "description": "Describes the CPU threshold at which scaling will occur.",
+                                          "required": ["type", "details"],
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": ["cpu"]
+                                            },
+                                            "details": {
+                                              "type": "object",
+                                              "required": ["utilization"],
+                                              "properties": {
+                                                "utilization": {
+                                                  "type": "integer"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "title": "StackSpecContainerScaleThresholdNetworkConnections",
+                                          "type": "object",
+                                          "description": "Describes the network connections threshold at which scaling will occur.",
+                                          "required": ["type", "details"],
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": ["network-connections"]
+                                            },
+                                            "details": {
+                                              "type": "object",
+                                              "required": ["connections_total"],
+                                              "properties": {
+                                                "connections_total": {
+                                                  "type": "integer"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "title": "StackSpecContainerScaleThresholdNetworkRequests",
+                                          "type": "object",
+                                          "description": "Describes the network requests threshold at which scaling will occur.",
+                                          "required": ["type", "details"],
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": ["network-requests"]
+                                            },
+                                            "details": {
+                                              "type": "object",
+                                              "required": ["requests_total"],
+                                              "properties": {
+                                                "requests_total": {
+                                                  "type": "integer"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "title": "StackSpecContainerScaleThresholdNetworkThroughput",
+                                          "type": "object",
+                                          "description": "Describes the network throughput threshold at which scaling will occur.",
+                                          "required": ["type", "details"],
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": ["network-throughput"]
+                                            },
+                                            "details": {
+                                              "type": "object",
+                                              "required": [
+                                                "private",
+                                                "bandwidth"
+                                              ],
+                                              "properties": {
+                                                "private": {
+                                                  "type": "boolean"
+                                                },
+                                                "bandwidth": {
+                                                  "type": "string",
+                                                  "description": "The limit (maximum) amount of throughput each instance of the given container can use before triggering a scaling event.",
+                                                  "examples": [
+                                                    "1gbps",
+                                                    "50mbps"
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              }
+                            }
+                          },
+                          { "$ref": "#/properties/about/oneOf/1" },
+                          { "type": "null" }
+                        ]
+                      },
+                      "runtime": {
+                        "anyOf": [
+                          {
+                            "title": "StackSpecContainerConfigRuntime",
+                            "description": "Configuration options related to how the container behaves while it is running (environment variables, command overrides, kernel capabilities, etc. )",
+                            "type": "object",
+                            "properties": {
+                              "workdir": {
+                                "description": "The working directory to execute the command in.",
+                                "oneOf": [
+                                  { "type": "string" },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "command": {
+                                "description": "The command to execute when this container starts. Will override the default specified in the container.",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "path": {
+                                        "oneOf": [
+                                          { "type": "string" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "args": {
+                                        "oneOf": [
+                                          { "type": "string" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "environment_vars": {
+                                "description": "A map of environment variables that will be injected into the container.",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "oneOf": [
+                                        { "type": "string" },
+                                        { "$ref": "#/properties/about/oneOf/1" }
+                                      ]
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "namespaces": {
+                                "description": "Container namespaces to apply. By default, all are applied. Removing/changing this can have security implications.",
+                                "oneOf": [
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string",
+                                      "enum": [
+                                        "ipc",
+                                        "pid",
+                                        "uts",
+                                        "network",
+                                        "mount",
+                                        "user",
+                                        "cgroup"
+                                      ]
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "sysctl": {
+                                "description": "Sysctl options to apply.",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "oneOf": [
+                                        { "type": "string" },
+                                        { "$ref": "#/properties/about/oneOf/1" }
+                                      ]
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "rlimits": {
+                                "description": "RLIMIT options to apply.",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "object",
+                                      "required": ["hard", "soft"],
+                                      "properties": {
+                                        "hard": {
+                                          "oneOf": [
+                                            { "type": "integer" },
+                                            {
+                                              "$ref": "#/properties/about/oneOf/1"
+                                            }
+                                          ]
+                                        },
+                                        "soft": {
+                                          "oneOf": [
+                                            { "type": "integer" },
+                                            {
+                                              "$ref": "#/properties/about/oneOf/1"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "seccomp": {
+                                "description": "Configuration options for seccomp. Cycle enables seccomp by default.",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": ["disable", "rules"],
+                                    "properties": {
+                                      "disable": {
+                                        "oneOf": [
+                                          { "type": "boolean" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "rules": {
+                                        "oneOf": [
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "oneOf": [
+                                                {
+                                                  "type": "object",
+                                                  "required": [
+                                                    "capabilities",
+                                                    "syscall"
+                                                  ],
+                                                  "properties": {
+                                                    "capabilities": {
+                                                      "oneOf": [
+                                                        {
+                                                          "type": "object",
+                                                          "required": [
+                                                            "includes",
+                                                            "excludes"
+                                                          ],
+                                                          "properties": {
+                                                            "includes": {
+                                                              "oneOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "$ref": "#/properties/about/oneOf/1"
+                                                                }
+                                                              ]
+                                                            },
+                                                            "excludes": {
+                                                              "oneOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "$ref": "#/properties/about/oneOf/1"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "$ref": "#/properties/about/oneOf/1"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "syscall": {
+                                                      "oneOf": [
+                                                        {
+                                                          "type": "object",
+                                                          "required": [
+                                                            "names",
+                                                            "action"
+                                                          ],
+                                                          "properties": {
+                                                            "names": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "action": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "SCMP_ACT_KILL",
+                                                                "SCMP_ACT_KILL_PROCESS",
+                                                                "SCMP_ACT_KILL_THREAD",
+                                                                "SCMP_ACT_TRAP",
+                                                                "SCMP_ACT_ERRNO",
+                                                                "SCMP_ACT_TRACE",
+                                                                "SCMP_ACT_ALLOW",
+                                                                "SCMP_ACT_LOG",
+                                                                "SCMP_ACT_NOTIFY"
+                                                              ]
+                                                            },
+                                                            "errnoRet": {
+                                                              "type": "integer"
+                                                            },
+                                                            "args": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                  "index",
+                                                                  "value",
+                                                                  "op"
+                                                                ],
+                                                                "properties": {
+                                                                  "index": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "value": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "valuetwo": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "op": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "SCMP_CMP_NE",
+                                                                      "SCMP_CMP_LT",
+                                                                      "SCMP_CMP_LE",
+                                                                      "SCMP_CMP_EQ",
+                                                                      "SCMP_CMP_GE",
+                                                                      "SCMP_CMP_GT",
+                                                                      "SCMP_CMP_MASKED_EQ"
+                                                                    ]
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "$ref": "#/properties/about/oneOf/1"
+                                                        }
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "$ref": "#/properties/about/oneOf/1"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "host": {
+                                "description": "Configuration options regarding the underlying host.",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                      "expose_proc": {
+                                        "description": "If true, Cycle will mount the `/proc` directory into the container, giving it access to the host metrics. This is useful if you're running i.e. a monitoring agent.",
+                                        "oneOf": [
+                                          { "type": ["boolean", "null"] },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "expose_cgroups": {
+                                        "description": "If true, Cycle will mount the host's `/sys/fs/cgroups` directory into the container at `/var/run/cycle/host/cgroups`.",
+                                        "oneOf": [
+                                          { "type": ["boolean", "null"] },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "power_management": {
+                                        "description": "If true, Cycle will give the container instances access via internal api to power off or reboot the host server.",
+                                        "oneOf": [
+                                          { "type": ["boolean", "null"] },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "privileged": {
+                                "description": "If true, the container process will run in fully-privileged mode. **WARNING** This is considered insecure, and should only be done if you know what you're doing.",
+                                "oneOf": [
+                                  { "type": "boolean" },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "capabilities": {
+                                "description": "Additional Linux kernel capabilities to apply to this container process.",
+                                "oneOf": [
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string",
+                                      "enum": [
+                                        "CAP_CHOWN",
+                                        "CAP_FSETID",
+                                        "CAP_DAC_OVERRIDE",
+                                        "CAP_FOWNER",
+                                        "CAP_SETFCAP",
+                                        "CAP_SETGID",
+                                        "CAP_SETUID",
+                                        "CAP_KILL",
+                                        "CAP_MKNOD",
+                                        "CAP_NET_BIND_SERVICE",
+                                        "CAP_NET_RAW",
+                                        "CAP_AUDIT_WRITE",
+                                        "CAP_SYS_CHROOT",
+                                        "CAP_SETPCAP",
+                                        "CAP_DAC_READ_SEARCH",
+                                        "CAP_NET_ADMIN",
+                                        "CAP_NET_BROADCAST",
+                                        "CAP_SYS_ADMIN",
+                                        "CAP_SYS_MODULE",
+                                        "CAP_SYS_NICE",
+                                        "CAP_SYS_PACCT",
+                                        "CAP_SYS_PTRACE",
+                                        "CAP_SYS_RAWIO",
+                                        "CAP_SYS_RESOURCE",
+                                        "CAP_SYS_BOOT",
+                                        "CAP_SYS_TIME",
+                                        "CAP_SYS_TTY_CONFIG",
+                                        "CAP_SYSLOG",
+                                        "CAP_AUDIT_CONTROL",
+                                        "CAP_AUDIT_READ",
+                                        "CAP_IPC_LOCK",
+                                        "CAP_IPC_OWNER",
+                                        "CAP_LINUX_IMMUTABLE",
+                                        "CAP_MAC_ADMIN",
+                                        "CAP_MAC_OVERRIDE",
+                                        "CAP_BLOCK_SUSPEND",
+                                        "CAP_LEASE",
+                                        "CAP_WAKE_ALARM"
+                                      ]
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "rootfs": {
+                                "description": "Configuration options for the root filesystem.",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": ["readonly"],
+                                    "properties": {
+                                      "readonly": {
+                                        "description": "If true, the container's filesystem will be read-only.",
+                                        "oneOf": [
+                                          { "type": "boolean" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "devices": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "shm_size": {
+                                        "oneOf": [
+                                          {
+                                            "type": "string",
+                                            "description": "The size of the shared host memory device (/dev/shm).",
+                                            "examples": ["64M", "128M", "512M"]
+                                          },
+                                          { "type": "null" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "expose": {
+                                        "anyOf": [
+                                          {
+                                            "type": "array",
+                                            "description": "An array of devices to expose to the container.",
+                                            "items": {
+                                              "title": "StackSpecRuntimeExposedDevice",
+                                              "type": "object",
+                                              "description": "A host device exposed to the container during runtime.",
+                                              "required": [
+                                                "source",
+                                                "destination"
+                                              ],
+                                              "properties": {
+                                                "source": {
+                                                  "description": "The path to the device on the host.",
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "string",
+                                                      "examples": [
+                                                        "/dev/kvm",
+                                                        "/dev/net/tun"
+                                                      ]
+                                                    },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ]
+                                                },
+                                                "destination": {
+                                                  "description": "The path inside the container that the device is mapped to.",
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "string",
+                                                      "examples": [
+                                                        "/dev/kvm",
+                                                        "/dev/net/tun"
+                                                      ]
+                                                    },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ]
+                                                },
+                                                "options": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "array",
+                                                      "description": "Options passed when mounting the device.",
+                                                      "items": {
+                                                        "type": "string",
+                                                        "examples": [
+                                                          "rbind",
+                                                          "ro"
+                                                        ]
+                                                      }
+                                                    },
+                                                    { "type": "null" },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          },
+                                          { "type": "null" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "permissions": {
+                                        "anyOf": [
+                                          {
+                                            "type": "array",
+                                            "description": "Rules for granting or denying access to a device node.",
+                                            "items": {
+                                              "title": "StackSpecRuntimeDevicePermission",
+                                              "type": "object",
+                                              "description": "A rule that grants or denies access to a device node (e.g., Linux cgroup device rule). Controls which device type and major/minor numbers are allowed, and with what access.\n",
+                                              "required": [
+                                                "type",
+                                                "allow",
+                                                "access"
+                                              ],
+                                              "properties": {
+                                                "type": {
+                                                  "oneOf": [
+                                                    {
+                                                      "title": "StackSpecRuntimeDevicePermissionType",
+                                                      "type": "string",
+                                                      "description": "The class of device this rule applies to (for example, block devices or character devices).\n",
+                                                      "enum": ["b", "c"]
+                                                    },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ]
+                                                },
+                                                "major": {
+                                                  "description": "Device major number.\n",
+                                                  "oneOf": [
+                                                    {
+                                                      "type": [
+                                                        "integer",
+                                                        "null"
+                                                      ],
+                                                      "format": "int64"
+                                                    },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ]
+                                                },
+                                                "minor": {
+                                                  "description": "Device minor number.\n",
+                                                  "oneOf": [
+                                                    {
+                                                      "type": [
+                                                        "integer",
+                                                        "null"
+                                                      ],
+                                                      "format": "int64"
+                                                    },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ]
+                                                },
+                                                "allow": {
+                                                  "oneOf": [
+                                                    { "type": "boolean" },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ],
+                                                  "description": "Whether this rule allows (true) or denies (false) access."
+                                                },
+                                                "access": {
+                                                  "oneOf": [
+                                                    {
+                                                      "title": "StackSpecRuntimeDevicePermissionAccess",
+                                                      "type": "string",
+                                                      "description": "The access mode permitted by this rule. Common conventions use a combination of letters (e.g., r, w, m) to indicate read, write, and mknod capabilities.\n",
+                                                      "pattern": "^[rwm]+$",
+                                                      "examples": [
+                                                        "r",
+                                                        "rw",
+                                                        "rwm"
+                                                      ]
+                                                    },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          },
+                                          { "type": "null" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "type": "null" },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              }
+                            }
+                          },
+                          { "$ref": "#/properties/about/oneOf/1" },
+                          { "type": "null" }
+                        ]
+                      },
+                      "resources": {
+                        "anyOf": [
+                          {
+                            "title": "StackSpecContainerConfigResources",
+                            "description": "Configuration options for container resource limits and reserves.",
+                            "type": "object",
+                            "required": ["cpu", "ram"],
+                            "properties": {
+                              "cpu": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "shares": {
+                                        "oneOf": [
+                                          {
+                                            "type": "object",
+                                            "required": ["limit", "reserve"],
+                                            "properties": {
+                                              "limit": {
+                                                "oneOf": [
+                                                  { "type": "integer" },
+                                                  {
+                                                    "$ref": "#/properties/about/oneOf/1"
+                                                  }
+                                                ]
+                                              },
+                                              "reserve": {
+                                                "oneOf": [
+                                                  { "type": "integer" },
+                                                  {
+                                                    "$ref": "#/properties/about/oneOf/1"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "cpus": { "type": "string" }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "ram": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "limit": {
+                                        "oneOf": [
+                                          { "type": "string" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "reserve": {
+                                        "oneOf": [
+                                          { "type": "string" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "swappiness": {
+                                        "oneOf": [
+                                          { "type": "number" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              }
+                            }
+                          },
+                          { "$ref": "#/properties/about/oneOf/1" },
+                          { "type": "null" }
+                        ]
+                      },
+                      "integrations": {
+                        "anyOf": [
+                          {
+                            "title": "StackSpecContainerConfigIntegrations",
+                            "type": "object",
+                            "description": "Configuration options for additional integrations/features that Cycle provides.",
+                            "properties": {
+                              "webhooks": {
+                                "description": "Enable additional webhooks that Cycle will call out to during the course of a container's lifetime. All webhooks send a payload as an object containing the instance, container, server, and environment IDs.",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                      "events": {
+                                        "description": "Webhooks that are triggered during a container event.",
+                                        "oneOf": [
+                                          {
+                                            "type": ["object", "null"],
+                                            "properties": {
+                                              "deploy": {
+                                                "description": "Cycle will call this endpoint when the container is deployed.",
+                                                "oneOf": [
+                                                  {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  {
+                                                    "$ref": "#/properties/about/oneOf/1"
+                                                  }
+                                                ]
+                                              },
+                                              "start": {
+                                                "description": "Cycle will call this endpoint when the container is started.",
+                                                "oneOf": [
+                                                  {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  {
+                                                    "$ref": "#/properties/about/oneOf/1"
+                                                  }
+                                                ]
+                                              },
+                                              "stop": {
+                                                "description": "Cycle will call this endpoint when the container is stopped.",
+                                                "oneOf": [
+                                                  {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  {
+                                                    "$ref": "#/properties/about/oneOf/1"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "config": {
+                                        "description": "The webhook to hit when the container's configuration is changed.",
+                                        "oneOf": [
+                                          { "type": ["string", "null"] },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "lets_encrypt": {
+                                "description": "When enabled, this integration will configure Let's Encrypt certificates that will be injected into the container at runtime. The certificates will be managed by the platform and renewed automatically.",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                      "certificate_path": {
+                                        "oneOf": [
+                                          { "type": ["string", "null"] },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "chain_path": {
+                                        "oneOf": [
+                                          { "type": ["string", "null"] },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "key_path": {
+                                        "oneOf": [
+                                          { "type": ["string", "null"] },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "bundle_path": {
+                                        "oneOf": [
+                                          { "type": ["string", "null"] },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "additional_certs_path": {
+                                        "oneOf": [
+                                          { "type": ["string", "null"] },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "files": {
+                                "description": "When enabled, Cycle will fetch and inject remote files into the container at the specified destination during runtime.",
+                                "oneOf": [
+                                  {
+                                    "type": ["array", "null"],
+                                    "items": {
+                                      "type": "object",
+                                      "required": ["source", "destination"],
+                                      "properties": {
+                                        "source": {
+                                          "oneOf": [
+                                            {
+                                              "$ref": "#/properties/about/oneOf/1"
+                                            },
+                                            { "type": "string" }
+                                          ]
+                                        },
+                                        "destination": {
+                                          "oneOf": [
+                                            { "type": "string" },
+                                            {
+                                              "$ref": "#/properties/about/oneOf/1"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "backups": {
+                                "description": "When enabled, Cycle will automatically manage backups of this container. This is only available for stateful containers.",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "required": [
+                                      "destination",
+                                      "backup",
+                                      "restore",
+                                      "retention"
+                                    ],
+                                    "properties": {
+                                      "integration_id": {
+                                        "description": "An identifier of an integration that supports backups. All backups will be sent to this destination.",
+                                        "oneOf": [
+                                          {
+                                            "$ref": "#/properties/containers/oneOf/0/additionalProperties/properties/volumes/oneOf/0/items/properties/external/anyOf/0/properties/id/oneOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "backup": {
+                                        "description": "Configuration options for how the container should be backed up.",
+                                        "oneOf": [
+                                          {
+                                            "type": "object",
+                                            "required": [
+                                              "command",
+                                              "timeout",
+                                              "cron_string"
+                                            ],
+                                            "properties": {
+                                              "command": {
+                                                "description": "The command to run to capture a backup. The output sent to `STDOUT` will be captured and sent to the specified integration.",
+                                                "oneOf": [
+                                                  { "type": "string" },
+                                                  {
+                                                    "$ref": "#/properties/about/oneOf/1"
+                                                  }
+                                                ]
+                                              },
+                                              "timeout": {
+                                                "description": "How long the backup will attempt to run before timing out.",
+                                                "anyOf": [
+                                                  {
+                                                    "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                                  },
+                                                  {
+                                                    "$ref": "#/properties/about/oneOf/1"
+                                                  },
+                                                  { "type": "null" }
+                                                ]
+                                              },
+                                              "cron_string": {
+                                                "description": "A cron string describing how often to run the backup command.",
+                                                "oneOf": [
+                                                  {
+                                                    "type": ["string", "null"]
+                                                  },
+                                                  {
+                                                    "$ref": "#/properties/about/oneOf/1"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "restore": {
+                                        "description": "Configuration options for how the backup should be restored.",
+                                        "oneOf": [
+                                          {
+                                            "type": ["object", "null"],
+                                            "required": ["command", "timeout"],
+                                            "properties": {
+                                              "command": {
+                                                "oneOf": [
+                                                  { "type": "string" },
+                                                  {
+                                                    "$ref": "#/properties/about/oneOf/1"
+                                                  }
+                                                ]
+                                              },
+                                              "timeout": {
+                                                "description": "The time in seconds for the restore to attempt to complete before timing out.",
+                                                "anyOf": [
+                                                  {
+                                                    "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                                  },
+                                                  {
+                                                    "$ref": "#/properties/about/oneOf/1"
+                                                  },
+                                                  { "type": "null" }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "retention": {
+                                        "description": "How long the platform will keep backups. Default is 1 year.",
+                                        "anyOf": [
+                                          {
+                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          },
+                                          { "type": "null" }
+                                        ],
+                                        "default": "365d"
+                                      }
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              },
+                              "shared_file_systems": {
+                                "description": "When enabled, Cycle will mount a shared host directory into this container. The directory will be shared with all other containers that mount it.",
+                                "oneOf": [
+                                  {
+                                    "type": ["object", "null"],
+                                    "additionalProperties": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "required": [
+                                            "writable",
+                                            "mount_point"
+                                          ],
+                                          "properties": {
+                                            "writable": {
+                                              "oneOf": [
+                                                { "type": "boolean" },
+                                                {
+                                                  "$ref": "#/properties/about/oneOf/1"
+                                                }
+                                              ]
+                                            },
+                                            "mount_point": {
+                                              "oneOf": [
+                                                {
+                                                  "$ref": "#/properties/about/oneOf/1"
+                                                },
+                                                { "type": "string" }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        { "$ref": "#/properties/about/oneOf/1" }
+                                      ]
+                                    }
+                                  },
+                                  { "$ref": "#/properties/about/oneOf/1" }
+                                ]
+                              }
+                            }
+                          },
+                          { "$ref": "#/properties/about/oneOf/1" },
+                          { "type": "null" }
+                        ]
+                      }
+                    }
+                  },
+                  { "$ref": "#/properties/about/oneOf/1" }
+                ]
+              },
+              "role": {
+                "description": "The role applied to this container. **Not yet implemented**",
+                "type": ["string", "null"],
+                "enum": ["conductor"]
+              },
+              "volumes": {
+                "description": "A list of configurations for volumes that will be attached to the container. Only applicable if the container is set to `stateful`.",
+                "oneOf": [
+                  {
+                    "type": ["array", "null"],
+                    "items": {
+                      "title": "StackSpecContainerVolume",
+                      "description": "A container volume configuration.",
+                      "type": "object",
+                      "required": ["destination"],
+                      "properties": {
+                        "local": {
+                          "description": "Configuration options for local volumes.",
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "required": ["max_size"],
+                              "properties": {
+                                "max_size": {
+                                  "description": "The maximum size this volume can grow to. Container volumes on Cycle are thinly provisioned, meaning this isn't an allocation - the volume will only use the space it needs up to this size.",
+                                  "oneOf": [
+                                    {
+                                      "type": "string",
+                                      "examples": ["5G", "500M"]
+                                    },
+                                    { "$ref": "#/properties/about/oneOf/1" }
+                                  ]
+                                },
+                                "storage_pool": {
+                                  "description": "A boolean where true signifies using the largest drive over 2TB for the target server.",
+                                  "oneOf": [
+                                    { "type": "boolean" },
+                                    { "$ref": "#/properties/about/oneOf/1" }
+                                  ]
+                                }
+                              }
+                            },
+                            { "$ref": "#/properties/about/oneOf/1" }
+                          ]
+                        },
+                        "external": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "oneOf": [
+                                    {
+                                      "title": "HybridIdentifier",
+                                      "type": "string",
+                                      "description": "Either a resource ID (objectid - i.e. 651586fca6078e98982dbd90) or a resource Identifier (human-readable)",
+                                      "examples": ["my-image-source"]
+                                    },
+                                    { "$ref": "#/properties/about/oneOf/1" },
+                                    { "type": "null" }
+                                  ],
+                                  "description": "The ID of the external volume."
+                                }
+                              }
+                            },
+                            { "$ref": "#/properties/about/oneOf/1" },
+                            { "type": "null" }
+                          ]
+                        },
+                        "destination": {
+                          "description": "The path this volume should be mounted at inside the container.",
+                          "oneOf": [
+                            { "type": "string" },
+                            { "$ref": "#/properties/about/oneOf/1" }
+                          ]
+                        },
+                        "read_only": {
+                          "description": "If true, the container will be unable to write data to the volume.",
+                          "oneOf": [
+                            { "type": "boolean" },
+                            { "$ref": "#/properties/about/oneOf/1" }
+                          ]
+                        },
+                        "block_device": {
+                          "oneOf": [
+                            { "type": "boolean" },
+                            { "$ref": "#/properties/about/oneOf/1" }
+                          ],
+                          "description": "Indicates that the volume will be used as unformatted block storage.\n"
+                        },
+                        "remote_access": {
+                          "description": "Configuration options for setting up remote access to this volume via SFTP.",
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "required": ["enable", "password"],
+                              "properties": {
+                                "enable": {
+                                  "description": "If true, this volume will be accessible over SFTP.",
+                                  "oneOf": [
+                                    { "type": "boolean" },
+                                    { "$ref": "#/properties/about/oneOf/1" }
+                                  ]
+                                },
+                                "ips": {
+                                  "description": "A list of IPs that SFTP access will be limited to.",
+                                  "oneOf": [
+                                    {
+                                      "type": "array",
+                                      "items": { "type": "string" }
+                                    },
+                                    { "$ref": "#/properties/about/oneOf/1" }
+                                  ]
+                                },
+                                "webhook": {
+                                  "description": "If set, Cycle will call out to this URL for authentication. Anything other than a 200 response will be considered a validation failure.",
+                                  "oneOf": [
+                                    { "type": "string" },
+                                    { "$ref": "#/properties/about/oneOf/1" }
+                                  ]
+                                },
+                                "password": {
+                                  "description": "The password used for logging in to this volume via SFTP.",
+                                  "oneOf": [
+                                    {
+                                      "type": "object",
+                                      "required": ["algorithm", "data"],
+                                      "properties": {
+                                        "algorithm": {
+                                          "description": "The algorithm the password is encoded with. `raw` means the password is plain-text.",
+                                          "oneOf": [
+                                            {
+                                              "type": "string",
+                                              "enum": ["raw", "sha512", "md5"]
+                                            },
+                                            {
+                                              "$ref": "#/properties/about/oneOf/1"
+                                            }
+                                          ]
+                                        },
+                                        "data": {
+                                          "description": "The password string.",
+                                          "oneOf": [
+                                            { "type": "string" },
+                                            {
+                                              "$ref": "#/properties/about/oneOf/1"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    { "$ref": "#/properties/about/oneOf/1" }
+                                  ]
+                                }
+                              }
+                            },
+                            { "$ref": "#/properties/about/oneOf/1" }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  { "$ref": "#/properties/about/oneOf/1" }
+                ]
+              },
+              "deprecate": {
+                "description": "If true, the container is marked as `deprecated`, and cannot be started anymore. Deprecated containers also don't count toward resource utilization.",
+                "oneOf": [
+                  { "type": "boolean" },
+                  { "$ref": "#/properties/about/oneOf/1" }
+                ]
+              },
+              "lock": {
+                "description": "If true, the container is marked as `locked` and cannot be deleted in any way until the lock is lifted.",
+                "oneOf": [
+                  { "type": "boolean" },
+                  { "$ref": "#/properties/about/oneOf/1" }
+                ]
+              }
+            }
+          }
+        },
+        { "$ref": "#/properties/about/oneOf/1" }
+      ]
+    },
+    "monitoring": {
+      "description": "Monitoring options for containers within this stack.",
+      "oneOf": [
+        {
+          "title": "StackSpecMonitoringConfig",
+          "description": "Monitoring options for the stack build & containers within this stack.",
+          "type": "object",
+          "properties": {
+            "logs": {
+              "oneOf": [
+                {
+                  "title": "StackSpecMonitoringLogs",
+                  "description": "Log configuration for containers in this stack.",
+                  "type": "object",
+                  "properties": {
+                    "logs": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "drain": {
+                              "description": "When enabled, log drain allows logs to be exported to a third party service.",
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "required": ["url", "exclude_services"],
+                                  "properties": {
+                                    "url": {
+                                      "description": "The URL to the third party logging service where logs will be sent.",
+                                      "oneOf": [
+                                        { "type": "string" },
+                                        { "$ref": "#/properties/about/oneOf/1" }
+                                      ]
+                                    },
+                                    "exclude_services": {
+                                      "description": "If enabled, service logs will not be included in log drain.",
+                                      "oneOf": [
+                                        { "type": "boolean" },
+                                        { "$ref": "#/properties/about/oneOf/1" }
+                                      ]
+                                    },
+                                    "format": {
+                                      "description": "The format Cycle will use to send the logs.",
+                                      "oneOf": [
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "ndjson-headers",
+                                            "ndjson-raw"
+                                          ]
+                                        },
+                                        { "type": "null" },
+                                        { "$ref": "#/properties/about/oneOf/1" }
+                                      ]
+                                    }
+                                  }
+                                },
+                                { "type": "null" },
+                                { "$ref": "#/properties/about/oneOf/1" }
+                              ]
+                            }
+                          }
+                        },
+                        { "type": "null" },
+                        { "$ref": "#/properties/about/oneOf/1" }
+                      ]
+                    }
+                  }
+                },
+                { "type": "null" },
+                { "$ref": "#/properties/about/oneOf/1" }
+              ]
+            }
+          }
+        },
+        { "$ref": "#/properties/about/oneOf/1" }
+      ]
+    },
+    "services": {
+      "description": "Settings for any auxillary services deployed as part of the environment, such as load balancer and discovery services.",
+      "oneOf": [
+        {
+          "title": "StackSpecServices",
+          "type": ["object", "null"],
+          "properties": {
+            "discovery": {
+              "anyOf": [
+                {
+                  "title": "StackSpecDiscoveryService",
+                  "description": "Configuration options for the discovery service.",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "service": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/properties/services/oneOf/0/properties/vpn/anyOf/0/properties/service/anyOf/0"
+                        },
+                        { "$ref": "#/properties/about/oneOf/1" },
+                        { "type": "null" }
+                      ]
+                    },
+                    "config": {
+                      "anyOf": [
+                        {
+                          "title": "StackSpecDiscoveryConfig",
+                          "type": "object",
+                          "properties": {
+                            "empty_set_delay": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                },
+                                { "$ref": "#/properties/about/oneOf/1" },
+                                { "type": "null" }
+                              ]
+                            },
+                            "dual_stack_legacy": {
+                              "description": "When enabled, discovery will return both IPv6 and IPv4 when in legacy mode.  Otherwise, only IPv4 will be returned.",
+                              "anyOf": [
+                                { "type": "boolean" },
+                                { "$ref": "#/properties/about/oneOf/1" },
+                                { "type": "null" }
+                              ]
+                            },
+                            "hosts": {
+                              "description": "A custom mapping of hosts - for forced resolution of specific IPs for a domain.",
+                              "oneOf": [
+                                {
+                                  "type": ["object", "null"],
+                                  "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                      "ipv4": {
+                                        "oneOf": [
+                                          {
+                                            "type": ["array", "null"],
+                                            "items": { "type": "string" }
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "ipv6": {
+                                        "oneOf": [
+                                          {
+                                            "type": ["array", "null"],
+                                            "items": { "type": "string" }
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                },
+                                { "$ref": "#/properties/about/oneOf/1" }
+                              ]
+                            },
+                            "custom_resolvers": {
+                              "description": "A list of custom DNS resolver strings.  Can specifify domains or ips.",
+                              "anyOf": [
+                                {
+                                  "type": "array",
+                                  "items": { "type": "string" }
+                                },
+                                { "$ref": "#/properties/about/oneOf/1" },
+                                { "type": "null" }
+                              ]
+                            }
+                          }
+                        },
+                        { "$ref": "#/properties/about/oneOf/1" },
+                        { "type": "null" }
+                      ]
+                    }
+                  }
+                },
+                { "$ref": "#/properties/about/oneOf/1" },
+                { "type": "null" }
+              ]
+            },
+            "loadbalancer": {
+              "anyOf": [
+                {
+                  "title": "StackSpecLoadBalancerService",
+                  "description": "Configuration options for the load balancer service.",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "service": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/properties/services/oneOf/0/properties/vpn/anyOf/0/properties/service/anyOf/0"
+                        },
+                        { "$ref": "#/properties/about/oneOf/1" },
+                        { "type": "null" }
+                      ]
+                    },
+                    "config": {
+                      "anyOf": [
+                        {
+                          "title": "StackSpecLoadBalancerConfig",
+                          "type": "object",
+                          "description": "The config object for the loadbalancer service.",
+                          "discriminator": {
+                            "propertyName": "type",
+                            "mapping": {
+                              "haproxy": "types/haproxy/StackSpecHaProxyLbType.yml",
+                              "v1": "types/v1/StackSpecV1LbType.yml",
+                              "default": "types/StackSpecDefaultLbType.yml"
+                            }
+                          },
+                          "oneOf": [
+                            {
+                              "title": "StackSpecHaProxyLbType",
+                              "type": "object",
+                              "required": ["type", "details", "ipv4", "ipv6"],
+                              "properties": {
+                                "ipv4": {
+                                  "description": "Allow / disallow traffic to be routed via IPv4.",
+                                  "oneOf": [
+                                    { "type": "boolean" },
+                                    { "$ref": "#/properties/about/oneOf/1" }
+                                  ]
+                                },
+                                "ipv6": {
+                                  "description": "Allow / disallow traffic to be routed via IPv6.",
+                                  "oneOf": [
+                                    { "type": "boolean" },
+                                    { "$ref": "#/properties/about/oneOf/1" }
+                                  ]
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["haproxy"]
+                                },
+                                "details": {
+                                  "anyOf": [
+                                    {
+                                      "title": "StackSpecHaProxyConfig",
+                                      "type": "object",
+                                      "description": "Describes settings that are passed to HAProxy within the load balancer.",
+                                      "required": ["default", "ports"],
+                                      "properties": {
+                                        "default": {
+                                          "description": "Settings that are applied to any port that is not overridden in the following ports section.",
+                                          "oneOf": [
+                                            {
+                                              "title": "StackSpecHAProxyConfigSet",
+                                              "type": "object",
+                                              "required": [
+                                                "frontend",
+                                                "backend"
+                                              ],
+                                              "properties": {
+                                                "frontend": {
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "object",
+                                                      "description": "Settings that describe how incoming traffic to the load balancer is handled.",
+                                                      "required": [
+                                                        "mode",
+                                                        "max_connections",
+                                                        "timeouts"
+                                                      ],
+                                                      "properties": {
+                                                        "mode": {
+                                                          "description": "The type of traffic expected by the load balancer for this port. Can be either: \n - tcp: Traffic is forwarded without any parsing or additional manipulation. \n - http: Traffic is treated as web traffic. If a LINKED record is configured for a container exposing this port, the domain will be parsed and it will be forwarded to the proper container. This allows multiple services to run on port 80 in the same environment.",
+                                                          "oneOf": [
+                                                            {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "tcp",
+                                                                "http"
+                                                              ]
+                                                            },
+                                                            {
+                                                              "$ref": "#/properties/about/oneOf/1"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "max_connections": {
+                                                          "description": "The number of simultaneous connections that can be processed at a time.",
+                                                          "oneOf": [
+                                                            {
+                                                              "type": [
+                                                                "integer",
+                                                                "null"
+                                                              ]
+                                                            },
+                                                            {
+                                                              "$ref": "#/properties/about/oneOf/1"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "timeouts": {
+                                                          "description": "Various options for handling timeouts when communicating with the client.",
+                                                          "oneOf": [
+                                                            {
+                                                              "type": [
+                                                                "object",
+                                                                "null"
+                                                              ],
+                                                              "required": [
+                                                                "client_secs",
+                                                                "client_fin_ms",
+                                                                "http_keep_alive_ms",
+                                                                "http_request_ms"
+                                                              ],
+                                                              "properties": {
+                                                                "client_secs": {
+                                                                  "description": "The number of seconds the load balancer will wait for a response from a client before disconnecting.",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "client_fin_ms": {
+                                                                  "description": "The number of milliseconds the load balancer will wait for a client to send it data when one direction is already closed. This is particularly useful to avoid keeping connections in a waiting state for too long when clients do not disconnect cleanly.",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "http_keep_alive_ms": {
+                                                                  "description": "The number of milliseconds the load balancer will wait for a new HTTP request to start coming after a response was set. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-timeout%20http-request) for more information. (`http` mode only)",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "http_request_ms": {
+                                                                  "description": "The number of milliseconds the load balancer will wait for a complete HTTP request. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-timeout%20http-request) for more information. (`http` mode only)",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "$ref": "#/properties/about/oneOf/1"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ]
+                                                },
+                                                "backend": {
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "object",
+                                                      "description": "Settings related to how the load balancer routes connections to container instances.",
+                                                      "required": [
+                                                        "balance",
+                                                        "timeouts"
+                                                      ],
+                                                      "properties": {
+                                                        "balance": {
+                                                          "description": "How connections are balanced across your container instances. Can be one of the following: \n - `roundrobin`: Each container instance is used in turns. \n - `static-rr`: Each container instance is used in turns, but is faster than Round Robin at the expense of being less dynamic. \n - `leastconn`: Routes traffic to the instance with the least number of active connections. \n - `first`: Routes traffic to the first available instance. \n - `source`: The same client IP always reaches the same container instance as long as no instance goes down or up.",
+                                                          "oneOf": [
+                                                            {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "roundrobin",
+                                                                "static-rr",
+                                                                "leastconn",
+                                                                "first",
+                                                                "source"
+                                                              ]
+                                                            },
+                                                            {
+                                                              "$ref": "#/properties/about/oneOf/1"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "timeouts": {
+                                                          "description": "Various options for handling timeouts when communicating with a container instance behind the load balancer.",
+                                                          "oneOf": [
+                                                            {
+                                                              "type": [
+                                                                "object",
+                                                                "null"
+                                                              ],
+                                                              "required": [
+                                                                "server_secs",
+                                                                "server_fin_ms",
+                                                                "connect_ms",
+                                                                "queue_ms",
+                                                                "tunnel_secs"
+                                                              ],
+                                                              "properties": {
+                                                                "server_secs": {
+                                                                  "description": "The number of seconds the load balancer will wait for a response from the container instance. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-timeout%20server) for more information.",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "server_fin_ms": {
+                                                                  "description": "The number of milliseconds the load balancer will wait for the server to send data when one direction is already closed. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-timeout%20server-fin) for more information.",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "connect_ms": {
+                                                                  "description": "The number of milliseconds the load balancer will wait for a successful connection to a container instance. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-timeout%20connect) for more information.",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "queue_ms": {
+                                                                  "description": "The number of milliseconds the load balancer will hold connections in a queue when the maximum number of connections has been reached. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-timeout%20queue) for more information.",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "tunnel_secs": {
+                                                                  "description": "The number of milliseconds the load balancer will allow for inactivity on a bidirectional tunnel. See the [HAProxy Docs](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-timeout%20tunnel) for more information.",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": [
+                                                                        "integer",
+                                                                        "null"
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "$ref": "#/properties/about/oneOf/1"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "$ref": "#/properties/about/oneOf/1"
+                                            }
+                                          ]
+                                        },
+                                        "ports": {
+                                          "description": "An object that defines how HAProxy will act on a specific port. The key is a custom port, and the value is the same settings object found under `default` above.",
+                                          "oneOf": [
+                                            {
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "oneOf": [
+                                                  {
+                                                    "$ref": "#/properties/services/oneOf/0/properties/loadbalancer/anyOf/0/properties/config/anyOf/0/oneOf/0/properties/details/anyOf/0/properties/default/oneOf/0"
+                                                  },
+                                                  {
+                                                    "$ref": "#/properties/about/oneOf/1"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "$ref": "#/properties/about/oneOf/1"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    { "$ref": "#/properties/about/oneOf/1" },
+                                    { "type": "null" }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "title": "StackSpecV1LbType",
+                              "type": "object",
+                              "required": ["type", "details", "ipv4", "ipv6"],
+                              "properties": {
+                                "ipv4": {
+                                  "description": "Allow / disallow traffic to be routed via IPv4.",
+                                  "oneOf": [
+                                    { "type": "boolean" },
+                                    { "$ref": "#/properties/about/oneOf/1" }
+                                  ]
+                                },
+                                "ipv6": {
+                                  "description": "Allow / disallow traffic to be routed via IPv6.",
+                                  "oneOf": [
+                                    { "type": "boolean" },
+                                    { "$ref": "#/properties/about/oneOf/1" }
+                                  ]
+                                },
+                                "type": { "type": "string", "enum": ["v1"] },
+                                "details": {
+                                  "oneOf": [
+                                    {
+                                      "title": "StackSpecV1LbConfig",
+                                      "type": "object",
+                                      "required": ["controllers"],
+                                      "properties": {
+                                        "controllers": {
+                                          "description": "A configuration for a specific port.",
+                                          "oneOf": [
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "$ref": "#/properties/services/oneOf/0/properties/loadbalancer/anyOf/0/properties/config/anyOf/0/oneOf/1/properties/details/oneOf/0/properties/controller_template/anyOf/0"
+                                              }
+                                            },
+                                            {
+                                              "$ref": "#/properties/about/oneOf/1"
+                                            }
+                                          ]
+                                        },
+                                        "controller_template": {
+                                          "anyOf": [
+                                            {
+                                              "title": "StackSpecV1LbController",
+                                              "type": "object",
+                                              "required": [
+                                                "identifier",
+                                                "port"
+                                              ],
+                                              "properties": {
+                                                "identifier": {
+                                                  "description": "A human-readable identifier for this controller. It will default to the port, i.e. `port-443`, but can be renamed to anything, such as the service this controller represents.",
+                                                  "oneOf": [
+                                                    { "type": "string" },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ]
+                                                },
+                                                "port": {
+                                                  "description": "The port inbound trafic is accepted on.",
+                                                  "oneOf": [
+                                                    { "type": "integer" },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ]
+                                                },
+                                                "waf": {
+                                                  "anyOf": [
+                                                    {
+                                                      "$ref": "#/properties/services/oneOf/0/properties/loadbalancer/anyOf/0/properties/config/anyOf/0/oneOf/1/properties/details/oneOf/0/properties/waf/anyOf/0"
+                                                    },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    },
+                                                    { "type": "null" }
+                                                  ]
+                                                },
+                                                "transport": {
+                                                  "title": "V1LbControllerTransport",
+                                                  "description": "Defines how traffic comes in to the load balancer, and how the load balancer handles it.",
+                                                  "oneOf": [
+                                                    {
+                                                      "type": [
+                                                        "object",
+                                                        "null"
+                                                      ],
+                                                      "required": [
+                                                        "mode",
+                                                        "config",
+                                                        "routers",
+                                                        "disable"
+                                                      ],
+                                                      "properties": {
+                                                        "disable": {
+                                                          "description": "When true, this controller is disabled and will not be used.",
+                                                          "oneOf": [
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "$ref": "#/properties/about/oneOf/1"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "mode": {
+                                                          "description": "The kind of traffic (http/tcp/udp) that will be sent to the load balancer.",
+                                                          "oneOf": [
+                                                            {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "tcp",
+                                                                "udp",
+                                                                "http"
+                                                              ]
+                                                            },
+                                                            {
+                                                              "$ref": "#/properties/about/oneOf/1"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "config": {
+                                                          "description": "Defines how the transport for this controller operates.",
+                                                          "oneOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "required": [
+                                                                "performance",
+                                                                "ingress",
+                                                                "timeouts",
+                                                                "verbosity"
+                                                              ],
+                                                              "properties": {
+                                                                "performance": {
+                                                                  "description": "Enable/disable performance mode. If enabled, some telemetry will be disabled to dedicate full processing to handling requests.\nYou will not see per-request breakdowns or URL logging if performance mode is enabled.\n",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "ingress": {
+                                                                  "description": "Defines how traffic gets into the load balancer.",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "tls": {
+                                                                          "oneOf": [
+                                                                            {
+                                                                              "type": [
+                                                                                "object",
+                                                                                "null"
+                                                                              ],
+                                                                              "required": [
+                                                                                "enable"
+                                                                              ],
+                                                                              "properties": {
+                                                                                "enable": {
+                                                                                  "description": "Enables or disables TLS.",
+                                                                                  "oneOf": [
+                                                                                    {
+                                                                                      "type": "boolean"
+                                                                                    },
+                                                                                    {
+                                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "$ref": "#/properties/about/oneOf/1"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "timeouts": {
+                                                                  "description": "Defines settings for various types of timeouts.",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": "object",
+                                                                      "required": [
+                                                                        "idle"
+                                                                      ],
+                                                                      "properties": {
+                                                                        "idle": {
+                                                                          "description": "The total amount of time a connection can be idle before being killed.",
+                                                                          "oneOf": [
+                                                                            {
+                                                                              "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                                                            },
+                                                                            {
+                                                                              "$ref": "#/properties/about/oneOf/1"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "verbosity": {
+                                                                  "description": "Verbosity describes the level of logging detail for the controller",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "low",
+                                                                        "normal",
+                                                                        "high",
+                                                                        "debug"
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "extension": {
+                                                                  "description": "Extended configurations for the specified transport mode (http/tcp)",
+                                                                  "oneOf": [
+                                                                    {
+                                                                      "type": "object",
+                                                                      "discriminator": {
+                                                                        "propertyName": "type",
+                                                                        "mapping": {
+                                                                          "tcp": "transports/StackSpecTcpTransportConfig.yml",
+                                                                          "http": "transports/StackSpecHttpTransportConfig.yml",
+                                                                          "udp": "transports/StackSpecUdpTransportConfig.yml"
+                                                                        }
+                                                                      },
+                                                                      "oneOf": [
+                                                                        {
+                                                                          "title": "StackSpecTcpTransportConfig",
+                                                                          "description": "Additional configuration options for the TCP transport mode.",
+                                                                          "type": "object",
+                                                                          "required": [
+                                                                            "type",
+                                                                            "details"
+                                                                          ],
+                                                                          "properties": {
+                                                                            "type": {
+                                                                              "type": "string",
+                                                                              "enum": [
+                                                                                "tcp"
+                                                                              ]
+                                                                            },
+                                                                            "details": {
+                                                                              "oneOf": [
+                                                                                {
+                                                                                  "type": "object",
+                                                                                  "required": [
+                                                                                    "connections",
+                                                                                    "telemetry"
+                                                                                  ],
+                                                                                  "properties": {
+                                                                                    "connections": {
+                                                                                      "oneOf": [
+                                                                                        {
+                                                                                          "type": "object",
+                                                                                          "additionalProperties": {}
+                                                                                        },
+                                                                                        {
+                                                                                          "$ref": "#/properties/about/oneOf/1"
+                                                                                        }
+                                                                                      ]
+                                                                                    },
+                                                                                    "telemetry": {
+                                                                                      "description": "Configuration options for how telemetry is handled on the load balancer.",
+                                                                                      "oneOf": [
+                                                                                        {
+                                                                                          "type": "object",
+                                                                                          "additionalProperties": {}
+                                                                                        },
+                                                                                        {
+                                                                                          "$ref": "#/properties/about/oneOf/1"
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "$ref": "#/properties/about/oneOf/1"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "title": "StackSpecHttpTransportConfig",
+                                                                          "description": "Additional configuration options for the HTTP transport mode.",
+                                                                          "type": "object",
+                                                                          "required": [
+                                                                            "type",
+                                                                            "details"
+                                                                          ],
+                                                                          "properties": {
+                                                                            "type": {
+                                                                              "type": "string",
+                                                                              "enum": [
+                                                                                "http"
+                                                                              ]
+                                                                            },
+                                                                            "details": {
+                                                                              "oneOf": [
+                                                                                {
+                                                                                  "type": "object",
+                                                                                  "required": [
+                                                                                    "connections",
+                                                                                    "telemetry"
+                                                                                  ],
+                                                                                  "properties": {
+                                                                                    "connections": {
+                                                                                      "oneOf": [
+                                                                                        {
+                                                                                          "type": "object",
+                                                                                          "required": [
+                                                                                            "max_idle_conns_per_connection"
+                                                                                          ],
+                                                                                          "description": "Defines extra configuration options connections to the load balancer",
+                                                                                          "properties": {
+                                                                                            "max_idle_conns_per_connection": {
+                                                                                              "oneOf": [
+                                                                                                {
+                                                                                                  "type": [
+                                                                                                    "integer",
+                                                                                                    "null"
+                                                                                                  ],
+                                                                                                  "description": "Maximum number of simultaneous connections (via http/2) per connection."
+                                                                                                },
+                                                                                                {
+                                                                                                  "$ref": "#/properties/about/oneOf/1"
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "$ref": "#/properties/about/oneOf/1"
+                                                                                        }
+                                                                                      ]
+                                                                                    },
+                                                                                    "telemetry": {
+                                                                                      "oneOf": [
+                                                                                        {
+                                                                                          "type": "object",
+                                                                                          "description": "Configuration options for how telemetry is handled.",
+                                                                                          "properties": {
+                                                                                            "max_trackable_urls": {
+                                                                                              "description": "Determines how many URLs the load balancer will track at one time. Defaults to 150.",
+                                                                                              "oneOf": [
+                                                                                                {
+                                                                                                  "type": [
+                                                                                                    "integer",
+                                                                                                    "null"
+                                                                                                  ]
+                                                                                                },
+                                                                                                {
+                                                                                                  "$ref": "#/properties/about/oneOf/1"
+                                                                                                }
+                                                                                              ]
+                                                                                            },
+                                                                                            "track_invalid_requests": {
+                                                                                              "description": "Whether or not to track invalid requests. An invalid request is a request that came in that no router existed for. Usually this means bot requests. Defaults to false.",
+                                                                                              "oneOf": [
+                                                                                                {
+                                                                                                  "type": [
+                                                                                                    "boolean",
+                                                                                                    "null"
+                                                                                                  ]
+                                                                                                },
+                                                                                                {
+                                                                                                  "$ref": "#/properties/about/oneOf/1"
+                                                                                                }
+                                                                                              ]
+                                                                                            },
+                                                                                            "ignore_paths": {
+                                                                                              "description": "An array of paths to exclude from tracking.",
+                                                                                              "oneOf": [
+                                                                                                {
+                                                                                                  "type": [
+                                                                                                    "array",
+                                                                                                    "null"
+                                                                                                  ],
+                                                                                                  "items": {
+                                                                                                    "type": "string"
+                                                                                                  }
+                                                                                                },
+                                                                                                {
+                                                                                                  "$ref": "#/properties/about/oneOf/1"
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "$ref": "#/properties/about/oneOf/1"
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "$ref": "#/properties/about/oneOf/1"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "title": "StackSpecUdpTransportConfig",
+                                                                          "description": "Additional configuration options for the UDP transport mode.",
+                                                                          "type": "object",
+                                                                          "required": [
+                                                                            "type",
+                                                                            "details"
+                                                                          ],
+                                                                          "properties": {
+                                                                            "type": {
+                                                                              "type": "string",
+                                                                              "enum": [
+                                                                                "udp"
+                                                                              ]
+                                                                            },
+                                                                            "details": {
+                                                                              "oneOf": [
+                                                                                {
+                                                                                  "type": "object",
+                                                                                  "required": [
+                                                                                    "telemetry"
+                                                                                  ],
+                                                                                  "properties": {
+                                                                                    "telemetry": {
+                                                                                      "description": "Configuration options for how telemetry is handled on the load balancer.",
+                                                                                      "oneOf": [
+                                                                                        {
+                                                                                          "type": "object",
+                                                                                          "additionalProperties": {}
+                                                                                        },
+                                                                                        {
+                                                                                          "$ref": "#/properties/about/oneOf/1"
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "$ref": "#/properties/about/oneOf/1"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "$ref": "#/properties/about/oneOf/1"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "routers": {
+                                                          "description": "Defines where traffic is sent. Many can be defined per controller.",
+                                                          "oneOf": [
+                                                            {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "oneOf": [
+                                                                  {
+                                                                    "title": "StackSpecV1LbRouterConfig",
+                                                                    "description": "A specific router configuration that describes how traffic matching the rule is handled.",
+                                                                    "type": "object",
+                                                                    "required": [
+                                                                      "match",
+                                                                      "mode",
+                                                                      "config"
+                                                                    ],
+                                                                    "properties": {
+                                                                      "match": {
+                                                                        "oneOf": [
+                                                                          {
+                                                                            "type": "object",
+                                                                            "description": "The ruleset for this router to be selected. If both `domains`` and `internal_port` are null, then this match acts as a wildcard and will match all.",
+                                                                            "required": [
+                                                                              "domains",
+                                                                              "internal_ports"
+                                                                            ],
+                                                                            "properties": {
+                                                                              "domains": {
+                                                                                "description": "The specific domains to match against.",
+                                                                                "oneOf": [
+                                                                                  {
+                                                                                    "type": [
+                                                                                      "array",
+                                                                                      "null"
+                                                                                    ],
+                                                                                    "items": {
+                                                                                      "type": "string"
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              "internal_ports": {
+                                                                                "description": "The specific ports to match against.",
+                                                                                "oneOf": [
+                                                                                  {
+                                                                                    "type": [
+                                                                                      "array",
+                                                                                      "null"
+                                                                                    ],
+                                                                                    "items": {
+                                                                                      "type": "integer"
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              "path": {
+                                                                                "oneOf": [
+                                                                                  {
+                                                                                    "type": [
+                                                                                      "string",
+                                                                                      "null"
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              "containers": {
+                                                                                "description": "Match traffic destined (or not destined) for a particular container.",
+                                                                                "oneOf": [
+                                                                                  {
+                                                                                    "type": [
+                                                                                      "object",
+                                                                                      "null"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                      "include": {
+                                                                                        "description": "Match any traffic that would be routed to one of these containers.",
+                                                                                        "oneOf": [
+                                                                                          {
+                                                                                            "type": [
+                                                                                              "array",
+                                                                                              "null"
+                                                                                            ],
+                                                                                            "items": {
+                                                                                              "$ref": "#/properties/containers/oneOf/0/additionalProperties/properties/volumes/oneOf/0/items/properties/external/anyOf/0/properties/id/oneOf/0"
+                                                                                            }
+                                                                                          },
+                                                                                          {
+                                                                                            "$ref": "#/properties/about/oneOf/1"
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      "exclude": {
+                                                                                        "description": "Match any traffic that would NOT be routed to one of these containers.",
+                                                                                        "oneOf": [
+                                                                                          {
+                                                                                            "type": [
+                                                                                              "array",
+                                                                                              "null"
+                                                                                            ],
+                                                                                            "items": {
+                                                                                              "$ref": "#/properties/containers/oneOf/0/additionalProperties/properties/volumes/oneOf/0/items/properties/external/anyOf/0/properties/id/oneOf/0"
+                                                                                            }
+                                                                                          },
+                                                                                          {
+                                                                                            "$ref": "#/properties/about/oneOf/1"
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "$ref": "#/properties/about/oneOf/1"
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      "mode": {
+                                                                        "description": "How to route the traffic to the destination.\n`random`: Pick a valid destination at random.\n`round-robin`: Send each request to the 'next' destination on the list, restarting from the beginning when the last destination is used.\n`source-ip`: Utilizes a hash function to ensure traffic from an IP will always hit the same destination instance.\n",
+                                                                        "oneOf": [
+                                                                          {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                              "random",
+                                                                              "round-robin",
+                                                                              "source-ip"
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "$ref": "#/properties/about/oneOf/1"
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      "config": {
+                                                                        "oneOf": [
+                                                                          {
+                                                                            "type": "object",
+                                                                            "required": [
+                                                                              "sticky_sessions",
+                                                                              "destination_retries",
+                                                                              "timeouts"
+                                                                            ],
+                                                                            "properties": {
+                                                                              "sticky_sessions": {
+                                                                                "description": "If a request comes in from the same origin, ensure it hits the same destination.",
+                                                                                "oneOf": [
+                                                                                  {
+                                                                                    "type": "boolean"
+                                                                                  },
+                                                                                  {
+                                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              "destination_retries": {
+                                                                                "description": "If a destination is unavailable, retry up to [x] times, instead of immediately failing with a 503/504 error.",
+                                                                                "oneOf": [
+                                                                                  {
+                                                                                    "type": "integer"
+                                                                                  },
+                                                                                  {
+                                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              "destination_prioritization": {
+                                                                                "oneOf": [
+                                                                                  {
+                                                                                    "type": "string",
+                                                                                    "description": "Hints to the load balancer how to prioritize traffic to instances.\n**random**: Chooses a random instance. **latency**: Prioritizes lower latency instances. **fixed**: The order of the destinations will be the same regardless of instance or load balancer location.  Used primarily with source IP routing.\n",
+                                                                                    "enum": [
+                                                                                      "latency",
+                                                                                      "random",
+                                                                                      "fixed"
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "null"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              "tls": {
+                                                                                "description": "TLS termination configuration. If null, the platform will use the default configuration. Port 443 by default has TLS termination enabled.",
+                                                                                "oneOf": [
+                                                                                  {
+                                                                                    "type": [
+                                                                                      "object",
+                                                                                      "null"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                      "server_name": {
+                                                                                        "description": "[Advanced] Change the domain the controller listens on.\n",
+                                                                                        "oneOf": [
+                                                                                          {
+                                                                                            "type": [
+                                                                                              "string",
+                                                                                              "null"
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "$ref": "#/properties/about/oneOf/1"
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      "allow_insecure": {
+                                                                                        "description": "If enabled, accept TLS traffic with an invalid certificate. This is usually done for development/testing, and is not recommended for production use.",
+                                                                                        "oneOf": [
+                                                                                          {
+                                                                                            "type": [
+                                                                                              "boolean",
+                                                                                              "null"
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "$ref": "#/properties/about/oneOf/1"
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      "client_cert_auth": {
+                                                                                        "description": "A PEM encoded string of certificates.",
+                                                                                        "oneOf": [
+                                                                                          {
+                                                                                            "type": [
+                                                                                              "string",
+                                                                                              "null"
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "$ref": "#/properties/about/oneOf/1"
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      "client_auth": {
+                                                                                        "description": "Defines how to validate the connecting TLS certificate.\n`none`: Do not require a TLS certificate to be sent\n`request`: Asks the client to send a TLS certificate, but does not require nor validate it.\n`require`: Requires a certificate be sent for the request to be valid, but does not validate the certificate.\n`require-verify`: Requires both that the client send a certificate, and that the certificate is valid. This is required when using https.\n",
+                                                                                        "oneOf": [
+                                                                                          {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                              "none",
+                                                                                              "request",
+                                                                                              "require",
+                                                                                              "require-verify"
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "$ref": "#/properties/about/oneOf/1"
+                                                                                          },
+                                                                                          {
+                                                                                            "type": "null"
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              "timeouts": {
+                                                                                "description": "Defines how the length of various sorts of timeouts when communicating with the destination.",
+                                                                                "oneOf": [
+                                                                                  {
+                                                                                    "type": "object",
+                                                                                    "required": [
+                                                                                      "destination_connection"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                      "destination_connection": {
+                                                                                        "description": "The duration the load balancer will wait before timing out while attempting to connect to the destination.",
+                                                                                        "oneOf": [
+                                                                                          {
+                                                                                            "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                                                                          },
+                                                                                          {
+                                                                                            "$ref": "#/properties/about/oneOf/1"
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              "extension": {
+                                                                                "anyOf": [
+                                                                                  {
+                                                                                    "type": "null"
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "object",
+                                                                                    "description": "Additional configuration options specific to the selected mode (tcp/http).",
+                                                                                    "discriminator": {
+                                                                                      "propertyName": "type",
+                                                                                      "mapping": {
+                                                                                        "tcp": "routers/StackSpecTcpRouterConfig.yml",
+                                                                                        "udp": "routers/StackSpecUdpRouterConfig.yml",
+                                                                                        "http": "routers/StackSpecHttpRouterConfig.yml"
+                                                                                      }
+                                                                                    },
+                                                                                    "oneOf": [
+                                                                                      {
+                                                                                        "title": "StackSpecTcpRouterConfig",
+                                                                                        "description": "Additional configuration options for TCP mode routers",
+                                                                                        "type": "object",
+                                                                                        "required": [
+                                                                                          "type",
+                                                                                          "details"
+                                                                                        ],
+                                                                                        "properties": {
+                                                                                          "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                              "tcp"
+                                                                                            ]
+                                                                                          },
+                                                                                          "details": {
+                                                                                            "oneOf": [
+                                                                                              {
+                                                                                                "type": "object",
+                                                                                                "additionalProperties": {}
+                                                                                              },
+                                                                                              {
+                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      {
+                                                                                        "title": "StackSpecHttpRouterConfig",
+                                                                                        "description": "Additional configuration options for HTTP mode routers.",
+                                                                                        "type": "object",
+                                                                                        "required": [
+                                                                                          "type",
+                                                                                          "details"
+                                                                                        ],
+                                                                                        "properties": {
+                                                                                          "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                              "http"
+                                                                                            ]
+                                                                                          },
+                                                                                          "details": {
+                                                                                            "oneOf": [
+                                                                                              {
+                                                                                                "type": "object",
+                                                                                                "properties": {
+                                                                                                  "redirect": {
+                                                                                                    "description": "Defines a built-in redirect for HTTP mode routers",
+                                                                                                    "oneOf": [
+                                                                                                      {
+                                                                                                        "type": [
+                                                                                                          "object",
+                                                                                                          "null"
+                                                                                                        ],
+                                                                                                        "required": [
+                                                                                                          "auto_https_redirect",
+                                                                                                          "remove_www"
+                                                                                                        ],
+                                                                                                        "properties": {
+                                                                                                          "auto_https_redirect": {
+                                                                                                            "description": "If enabled and a sibling controller exists for port 443, requests will be auto redirected to it. Essentially sets up automatic TLS redirection for this router.",
+                                                                                                            "oneOf": [
+                                                                                                              {
+                                                                                                                "type": "boolean"
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          },
+                                                                                                          "remove_www": {
+                                                                                                            "description": "If true, any request comes in with \"www\" prefix will be permanently redirected to the same path without www.",
+                                                                                                            "oneOf": [
+                                                                                                              {
+                                                                                                                "type": "boolean"
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          },
+                                                                                                          "port": {
+                                                                                                            "description": "The port to redirect traffic to.",
+                                                                                                            "oneOf": [
+                                                                                                              {
+                                                                                                                "type": [
+                                                                                                                  "integer",
+                                                                                                                  "null"
+                                                                                                                ]
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          },
+                                                                                                          "scheme": {
+                                                                                                            "description": "The scheme to redirect to. (i.e. `https`)",
+                                                                                                            "oneOf": [
+                                                                                                              {
+                                                                                                                "type": [
+                                                                                                                  "string",
+                                                                                                                  "null"
+                                                                                                                ]
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          },
+                                                                                                          "url": {
+                                                                                                            "description": "A specific URL to redirect to.",
+                                                                                                            "oneOf": [
+                                                                                                              {
+                                                                                                                "type": [
+                                                                                                                  "string",
+                                                                                                                  "null"
+                                                                                                                ]
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        }
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "$ref": "#/properties/about/oneOf/1"
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  },
+                                                                                                  "forward": {
+                                                                                                    "oneOf": [
+                                                                                                      {
+                                                                                                        "type": [
+                                                                                                          "object",
+                                                                                                          "null"
+                                                                                                        ],
+                                                                                                        "properties": {
+                                                                                                          "scheme": {
+                                                                                                            "oneOf": [
+                                                                                                              {
+                                                                                                                "type": [
+                                                                                                                  "string",
+                                                                                                                  "null"
+                                                                                                                ]
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          },
+                                                                                                          "content_mod": {
+                                                                                                            "description": "Allows the load balancer to modify content before it reaches the user.",
+                                                                                                            "oneOf": [
+                                                                                                              {
+                                                                                                                "type": [
+                                                                                                                  "object",
+                                                                                                                  "null"
+                                                                                                                ],
+                                                                                                                "properties": {
+                                                                                                                  "replace": {
+                                                                                                                    "description": "An array that describes a list of replacement match/value pairs.",
+                                                                                                                    "oneOf": [
+                                                                                                                      {
+                                                                                                                        "type": [
+                                                                                                                          "array",
+                                                                                                                          "null"
+                                                                                                                        ],
+                                                                                                                        "items": {
+                                                                                                                          "oneOf": [
+                                                                                                                            {
+                                                                                                                              "type": "object",
+                                                                                                                              "required": [
+                                                                                                                                "match",
+                                                                                                                                "value"
+                                                                                                                              ],
+                                                                                                                              "properties": {
+                                                                                                                                "match": {
+                                                                                                                                  "description": "String that will be replaced.",
+                                                                                                                                  "oneOf": [
+                                                                                                                                    {
+                                                                                                                                      "type": "string"
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                                                                                    }
+                                                                                                                                  ]
+                                                                                                                                },
+                                                                                                                                "value": {
+                                                                                                                                  "description": "Replacement value.",
+                                                                                                                                  "oneOf": [
+                                                                                                                                    {
+                                                                                                                                      "type": "string"
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                                                                                    }
+                                                                                                                                  ]
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                              "$ref": "#/properties/about/oneOf/1"
+                                                                                                                            }
+                                                                                                                          ]
+                                                                                                                        }
+                                                                                                                      },
+                                                                                                                      {
+                                                                                                                        "$ref": "#/properties/about/oneOf/1"
+                                                                                                                      }
+                                                                                                                    ]
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          },
+                                                                                                          "url": {
+                                                                                                            "description": "The URL to forward the request to.\n\nGiven a path match of `^/example/(.*)$`, a route such as `/example/wow.jpg` would be forwarded as /wow.jpg.\n",
+                                                                                                            "examples": [
+                                                                                                              "/$$1"
+                                                                                                            ],
+                                                                                                            "oneOf": [
+                                                                                                              {
+                                                                                                                "type": "string"
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        }
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "$ref": "#/properties/about/oneOf/1"
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  },
+                                                                                                  "proxy": {
+                                                                                                    "oneOf": [
+                                                                                                      {
+                                                                                                        "type": [
+                                                                                                          "object",
+                                                                                                          "null"
+                                                                                                        ],
+                                                                                                        "properties": {
+                                                                                                          "domain": {
+                                                                                                            "description": "The domain that this router will proxy.",
+                                                                                                            "oneOf": [
+                                                                                                              {
+                                                                                                                "type": [
+                                                                                                                  "string",
+                                                                                                                  "null"
+                                                                                                                ]
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          },
+                                                                                                          "url": {
+                                                                                                            "description": "The full URL that this router will proxy.",
+                                                                                                            "oneOf": [
+                                                                                                              {
+                                                                                                                "type": "string"
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "type": "null"
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          },
+                                                                                                          "content_mod": {
+                                                                                                            "description": "Allows the load balancer to modify content before it reaches the user.",
+                                                                                                            "oneOf": [
+                                                                                                              {
+                                                                                                                "type": [
+                                                                                                                  "object",
+                                                                                                                  "null"
+                                                                                                                ],
+                                                                                                                "properties": {
+                                                                                                                  "replace": {
+                                                                                                                    "description": "An array that describes a list of replacement match/value pairs.",
+                                                                                                                    "oneOf": [
+                                                                                                                      {
+                                                                                                                        "type": [
+                                                                                                                          "array",
+                                                                                                                          "null"
+                                                                                                                        ],
+                                                                                                                        "items": {
+                                                                                                                          "oneOf": [
+                                                                                                                            {
+                                                                                                                              "type": "object",
+                                                                                                                              "required": [
+                                                                                                                                "match",
+                                                                                                                                "value"
+                                                                                                                              ],
+                                                                                                                              "properties": {
+                                                                                                                                "match": {
+                                                                                                                                  "description": "String that will be replaced.",
+                                                                                                                                  "oneOf": [
+                                                                                                                                    {
+                                                                                                                                      "type": "string"
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                                                                                    }
+                                                                                                                                  ]
+                                                                                                                                },
+                                                                                                                                "value": {
+                                                                                                                                  "description": "Replacement value.",
+                                                                                                                                  "oneOf": [
+                                                                                                                                    {
+                                                                                                                                      "type": "string"
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                                                                                    }
+                                                                                                                                  ]
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                              "$ref": "#/properties/about/oneOf/1"
+                                                                                                                            }
+                                                                                                                          ]
+                                                                                                                        }
+                                                                                                                      },
+                                                                                                                      {
+                                                                                                                        "$ref": "#/properties/about/oneOf/1"
+                                                                                                                      }
+                                                                                                                    ]
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        }
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "$ref": "#/properties/about/oneOf/1"
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  },
+                                                                                                  "caching": {
+                                                                                                    "oneOf": [
+                                                                                                      {
+                                                                                                        "type": [
+                                                                                                          "object",
+                                                                                                          "null"
+                                                                                                        ],
+                                                                                                        "properties": {
+                                                                                                          "files": {
+                                                                                                            "oneOf": [
+                                                                                                              {
+                                                                                                                "type": [
+                                                                                                                  "array",
+                                                                                                                  "null"
+                                                                                                                ],
+                                                                                                                "items": {
+                                                                                                                  "oneOf": [
+                                                                                                                    {
+                                                                                                                      "type": "object",
+                                                                                                                      "required": [
+                                                                                                                        "match",
+                                                                                                                        "ttl"
+                                                                                                                      ],
+                                                                                                                      "properties": {
+                                                                                                                        "match": {
+                                                                                                                          "description": "Regex string that describes the files to cache.",
+                                                                                                                          "examples": [
+                                                                                                                            "(.*)\\.(js|jpg|css|png|svg)$"
+                                                                                                                          ],
+                                                                                                                          "oneOf": [
+                                                                                                                            {
+                                                                                                                              "type": "string"
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                              "$ref": "#/properties/about/oneOf/1"
+                                                                                                                            }
+                                                                                                                          ]
+                                                                                                                        },
+                                                                                                                        "ttl": {
+                                                                                                                          "description": "Time string that describes the time to live.",
+                                                                                                                          "oneOf": [
+                                                                                                                            {
+                                                                                                                              "$ref": "#/properties/scoped_variables/oneOf/0/items/properties/access/oneOf/0/properties/internal_api/oneOf/0/properties/duration/anyOf/0"
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                              "$ref": "#/properties/about/oneOf/1"
+                                                                                                                            }
+                                                                                                                          ]
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "$ref": "#/properties/about/oneOf/1"
+                                                                                                                    }
+                                                                                                                  ]
+                                                                                                                }
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        }
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "$ref": "#/properties/about/oneOf/1"
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      {
+                                                                                        "title": "StackSpecUdpRouterConfig",
+                                                                                        "description": "Additional configuration options for UDP mode routers",
+                                                                                        "type": "object",
+                                                                                        "required": [
+                                                                                          "type",
+                                                                                          "details"
+                                                                                        ],
+                                                                                        "properties": {
+                                                                                          "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                              "udp"
+                                                                                            ]
+                                                                                          },
+                                                                                          "details": {
+                                                                                            "oneOf": [
+                                                                                              {
+                                                                                                "type": "object",
+                                                                                                "additionalProperties": {}
+                                                                                              },
+                                                                                              {
+                                                                                                "$ref": "#/properties/about/oneOf/1"
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "$ref": "#/properties/about/oneOf/1"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "$ref": "#/properties/about/oneOf/1"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "$ref": "#/properties/about/oneOf/1"
+                                            },
+                                            { "type": "null" }
+                                          ]
+                                        },
+                                        "waf": {
+                                          "anyOf": [
+                                            {
+                                              "title": "StackSpecWafConfig",
+                                              "type": "object",
+                                              "description": "Additional configuration options for the web application firewall.",
+                                              "required": ["rules"],
+                                              "properties": {
+                                                "rules": {
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "description",
+                                                              "skip",
+                                                              "type",
+                                                              "conditions"
+                                                            ],
+                                                            "properties": {
+                                                              "description": {
+                                                                "description": "Some information about the rule.",
+                                                                "oneOf": [
+                                                                  {
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "skip": {
+                                                                "description": "A boolean that indicates if the rule should be active or skipped.",
+                                                                "oneOf": [
+                                                                  {
+                                                                    "type": "boolean"
+                                                                  },
+                                                                  {
+                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "type": {
+                                                                "description": "A string that describes if the role should allow or deny traffic based on the conditions.",
+                                                                "oneOf": [
+                                                                  {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "allow",
+                                                                      "deny"
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "expires": {
+                                                                "description": "The expiration date of the WAF config, if present.",
+                                                                "oneOf": [
+                                                                  {
+                                                                    "type": "string",
+                                                                    "format": "date-time",
+                                                                    "examples": [
+                                                                      "2021-01-30T08:30:00Z"
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "match": {
+                                                                "description": "A string that describes if both attributes need to be true (match all) or if only one of the conditions needs to be true (match any).",
+                                                                "oneOf": [
+                                                                  {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "any",
+                                                                      "all"
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "conditions": {
+                                                                "description": "An array of the specific conditions for the rule.",
+                                                                "oneOf": [
+                                                                  {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                      "oneOf": [
+                                                                        {
+                                                                          "type": "object",
+                                                                          "required": [
+                                                                            "type",
+                                                                            "operator",
+                                                                            "value"
+                                                                          ],
+                                                                          "properties": {
+                                                                            "type": {
+                                                                              "description": "A string that describes the match type for the condition.",
+                                                                              "oneOf": [
+                                                                                {
+                                                                                  "type": "string",
+                                                                                  "enum": [
+                                                                                    "ip-match",
+                                                                                    "geo-match",
+                                                                                    "url-match",
+                                                                                    "method-match",
+                                                                                    "header-match"
+                                                                                  ]
+                                                                                },
+                                                                                {
+                                                                                  "$ref": "#/properties/about/oneOf/1"
+                                                                                }
+                                                                              ]
+                                                                            },
+                                                                            "operator": {
+                                                                              "description": "A string that indicates the range of values relative to the value property.",
+                                                                              "oneOf": [
+                                                                                {
+                                                                                  "type": "string",
+                                                                                  "enum": [
+                                                                                    "==",
+                                                                                    "!=",
+                                                                                    ">",
+                                                                                    "<",
+                                                                                    ">=",
+                                                                                    "<="
+                                                                                  ]
+                                                                                },
+                                                                                {
+                                                                                  "$ref": "#/properties/about/oneOf/1"
+                                                                                }
+                                                                              ]
+                                                                            },
+                                                                            "value": {
+                                                                              "description": "The value corresponding to the condition type.",
+                                                                              "examples": [
+                                                                                "0.0.0.0/0"
+                                                                              ],
+                                                                              "oneOf": [
+                                                                                {
+                                                                                  "type": "string"
+                                                                                },
+                                                                                {
+                                                                                  "$ref": "#/properties/about/oneOf/1"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "$ref": "#/properties/about/oneOf/1"
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "$ref": "#/properties/about/oneOf/1"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "$ref": "#/properties/about/oneOf/1"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    {
+                                                      "$ref": "#/properties/about/oneOf/1"
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "$ref": "#/properties/about/oneOf/1"
+                                            },
+                                            { "type": "null" }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    { "$ref": "#/properties/about/oneOf/1" }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "title": "StackSpecDefaultLbType",
+                              "type": "object",
+                              "required": ["type", "details", "ipv4", "ipv6"],
+                              "properties": {
+                                "ipv4": {
+                                  "type": "boolean",
+                                  "description": "Allow / disallow traffic to be routed via IPv4."
+                                },
+                                "ipv6": {
+                                  "type": "boolean",
+                                  "description": "Allow / disallow traffic to be routed via IPv6."
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["default"]
+                                },
+                                "details": {
+                                  "oneOf": [
+                                    {
+                                      "$ref": "#/properties/services/oneOf/0/properties/loadbalancer/anyOf/0/properties/config/anyOf/0/oneOf/0/properties/details/anyOf/0"
+                                    },
+                                    {
+                                      "$ref": "#/properties/services/oneOf/0/properties/loadbalancer/anyOf/0/properties/config/anyOf/0/oneOf/1/properties/details/oneOf/0"
+                                    },
+                                    { "type": "null" }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        { "$ref": "#/properties/about/oneOf/1" },
+                        { "type": "null" }
+                      ]
+                    }
+                  }
+                },
+                { "$ref": "#/properties/about/oneOf/1" },
+                { "type": "null" }
+              ]
+            },
+            "scheduler": {
+              "anyOf": [
+                {
+                  "title": "StackSpecSchedulerService",
+                  "description": "Configuration options for the scheduler service.",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "service": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/properties/services/oneOf/0/properties/vpn/anyOf/0/properties/service/anyOf/0"
+                        },
+                        { "$ref": "#/properties/about/oneOf/1" },
+                        { "type": "null" }
+                      ]
+                    },
+                    "config": {
+                      "anyOf": [
+                        {
+                          "title": "StackSpecSchedulerConfig",
+                          "description": "Scheduler specific configuration options.",
+                          "type": ["object", "null"],
+                          "required": ["public"],
+                          "properties": {
+                            "public": {
+                              "description": "If true, this scheduler will be accessible over the public internet. It will enable a LINKED record to be pointed to the scheduler container, and inbound requests to trigger function containers.",
+                              "oneOf": [
+                                { "type": "boolean" },
+                                { "$ref": "#/properties/about/oneOf/1" }
+                              ]
+                            },
+                            "access_keys": {
+                              "oneOf": [
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "title": "StackSpecSchedulerAccessKey",
+                                    "description": "Custom authorization keys for the scheduler service.",
+                                    "type": "object",
+                                    "required": ["name", "secret"],
+                                    "properties": {
+                                      "name": {
+                                        "description": "The name given to this access key.",
+                                        "oneOf": [
+                                          { "type": "string" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "secret": {
+                                        "description": "The access key secret. This should be submitted with requests to a publicly accessible scheduler service.",
+                                        "oneOf": [
+                                          { "type": "string" },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      },
+                                      "ips": {
+                                        "description": "Whitelisted IPs that are allowed to make requests to the scheduler service.",
+                                        "oneOf": [
+                                          {
+                                            "type": "array",
+                                            "items": { "type": "string" }
+                                          },
+                                          {
+                                            "$ref": "#/properties/about/oneOf/1"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                },
+                                { "$ref": "#/properties/about/oneOf/1" }
+                              ]
+                            }
+                          }
+                        },
+                        { "$ref": "#/properties/about/oneOf/1" },
+                        { "type": "null" }
+                      ]
+                    }
+                  }
+                },
+                { "$ref": "#/properties/about/oneOf/1" },
+                { "type": "null" }
+              ]
+            },
+            "vpn": {
+              "anyOf": [
+                {
+                  "title": "StackSpecVpnService",
+                  "description": "Configuration options for the VPN service.",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "service": {
+                      "anyOf": [
+                        {
+                          "title": "StackService",
+                          "description": "Stack spec configuration options common to all environment services. If one of these properties is defined, all must be.",
+                          "type": "object",
+                          "properties": {
+                            "enable": {
+                              "description": "Whether or not this service should be enabled.",
+                              "type": "boolean"
+                            },
+                            "high_availability": {
+                              "description": "Whether or not Cycle should run multiple instances of this service for high availability.",
+                              "type": "boolean"
+                            },
+                            "auto_update": {
+                              "description": "Whether or not Cycle should automatically update this service when a new version is released.",
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        { "$ref": "#/properties/about/oneOf/1" },
+                        { "type": "null" }
+                      ]
+                    },
+                    "config": {
+                      "anyOf": [
+                        {
+                          "title": "StackSpecVpnConfig",
+                          "description": "VPN specific configuraiton options.",
+                          "type": "object",
+                          "required": ["auth", "allow_internet"],
+                          "properties": {
+                            "auth": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "required": [
+                                    "cycle_accounts",
+                                    "vpn_accounts"
+                                  ],
+                                  "properties": {
+                                    "webhook": {
+                                      "description": "The endpoint to hit when attempting to authorize a VPN account. If the endpoint returns a 200 response, access is granted. Otherwise it is denied.",
+                                      "oneOf": [
+                                        { "type": "string" },
+                                        { "$ref": "#/properties/about/oneOf/1" }
+                                      ]
+                                    },
+                                    "cycle_accounts": {
+                                      "description": "If true, any account with access to this environment on Cycle can use their Cycle credentials to log in to this VPN.",
+                                      "oneOf": [
+                                        { "type": "boolean" },
+                                        { "$ref": "#/properties/about/oneOf/1" }
+                                      ]
+                                    },
+                                    "vpn_accounts": {
+                                      "description": "If true, Cycle will allow custom accounts to be created for logging into this VPN.",
+                                      "oneOf": [
+                                        { "type": "boolean" },
+                                        { "$ref": "#/properties/about/oneOf/1" }
+                                      ]
+                                    }
+                                  }
+                                },
+                                { "$ref": "#/properties/about/oneOf/1" }
+                              ]
+                            },
+                            "allow_internet": {
+                              "oneOf": [
+                                { "type": "boolean" },
+                                { "$ref": "#/properties/about/oneOf/1" }
+                              ]
+                            },
+                            "custom_directives": {
+                              "type": ["string", "null"],
+                              "description": "Additional OpenVPN directives that will be appended to the server configuration on service start. Each line should follow standard OpenVPN syntax.\n",
+                              "examples": [
+                                "client-to-client\nduplicate-cn\npersist-key\npersist-tun\n",
+                                "verb 3\nmute 10\n"
+                              ]
+                            }
+                          }
+                        },
+                        { "$ref": "#/properties/about/oneOf/1" },
+                        { "type": "null" }
+                      ]
+                    }
+                  }
+                },
+                { "$ref": "#/properties/about/oneOf/1" },
+                { "type": "null" }
+              ]
+            }
+          }
+        },
+        { "$ref": "#/properties/about/oneOf/1" }
+      ]
+    },
+    "annotations": {
+      "description": "Additional meta info about the stack.",
+      "oneOf": [
+        { "type": "object", "additionalProperties": {} },
+        { "$ref": "#/properties/about/oneOf/1" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
We were naming too many things <Resource>Includes. This led to duplicate names that referred to different levels of includes.

Now, `<Resource>Includes` is made up in individual `Included<Resources>` line items.

An Example:

PipelineRunIncludes:
creators: ./IncludedCreators.yml
pipelines: ./IncludedPipelines.yml
key: ./IncludedKeys.yml

Also, did a global replace of `"$ref:"` getting rid of the quotes.  It makes the YAML formatter easier to read, and the quotes are not neccessary.