### PR TITLE
Add domain suffix option to discovery config

### DIFF
--- a/components/schemas/environments/services/discovery/DiscoveryConfig.yml
+++ b/components/schemas/environments/services/discovery/DiscoveryConfig.yml
@@ -53,5 +53,4 @@ properties:
   domain_suffix:
     anyOf:
       - type: string
-      - $ref: ../../StackVariable.yml
       - type: "null"

--- a/components/schemas/environments/services/discovery/DiscoveryConfig.yml
+++ b/components/schemas/environments/services/discovery/DiscoveryConfig.yml
@@ -50,3 +50,8 @@ properties:
             type: string
             enum: [default, ipv4, ipv6]
       - type: "null"
+  domain_suffix:
+    anyOf:
+      - type: string
+      - $ref: ../../StackVariable.yml
+      - type: "null"

--- a/stackspec/schema/services/discovery/StackSpecDiscoveryConfig.yml
+++ b/stackspec/schema/services/discovery/StackSpecDiscoveryConfig.yml
@@ -57,3 +57,8 @@ properties:
             enum: [default, ipv4, ipv6]
       - $ref: ../../StackVariable.yml
       - type: "null"
+  domain_suffix:
+    anyOf:
+      - type: string
+      - $ref: ../../StackVariable.yml
+      - type: "null"


### PR DESCRIPTION
This new option allows you to add a custom domain that will resolve to the target discovery service. This is especially useful when dealing with connecting to multiple VPNs and trying to explicitly define which service in which environment you're hitting.