### PR TITLE
Add egress and route options to container network config

### DIFF
--- a/components/schemas/containers/config/ContainerNetwork.yml
+++ b/components/schemas/containers/config/ContainerNetwork.yml
@@ -3,16 +3,28 @@ type: object
 description: Network configuration for a container.
 required:
   - public
+  - egress_via_gateway
+  - routes
   - hostname
 properties:
   public:
     type: string
-    description: The public network settings for the given container
+    description: The public network settings for the given container.
     enum:
       - enable
       - egress-only
       - environment-limited
       - disable
+  egress_via_gateway:
+    type: boolean
+    description: When true, the container's egress traffic is routed out through the environment gateway.
+  routes:
+    type:
+      - array
+      - "null"
+    description: Custom network routes applied to the container's instances.
+    items:
+      $ref: ./network/NetworkRoute.yml
   hostname:
     type: string
     description: The hostname for the given container.

--- a/components/schemas/containers/config/network/NetworkRoute.yml
+++ b/components/schemas/containers/config/network/NetworkRoute.yml
@@ -1,0 +1,18 @@
+title: NetworkRoute
+type: object
+description: A single network route directing traffic for a destination network.
+required:
+  - destination
+  - gateway
+properties:
+  destination:
+    description: The destination network, in CIDR notation, that this route matches.
+    oneOf:
+      - $ref: ../../../Cidr.yml
+      - type: "null"
+  gateway:
+    description: The IP address that traffic matching the destination is forwarded to.
+    $ref: ../../../IpAddress.yml
+  interface:
+    type: string
+    description: The name of the network interface this route is bound to.

--- a/stackspec/schema/StackSpecContainerConfigNetwork.yml
+++ b/stackspec/schema/StackSpecContainerConfigNetwork.yml
@@ -16,6 +16,40 @@ properties:
           - egress-only
           - environment-limited
       - $ref: StackVariable.yml
+  egress_via_gateway:
+    description: When true, the container's egress traffic is routed out through the environment gateway.
+    oneOf:
+      - type: boolean
+      - $ref: StackVariable.yml
+  routes:
+    description: Custom network routes applied to the container's instances.
+    oneOf:
+      - type: array
+        items:
+          title: NetworkRoute
+          type: object
+          description: A single network route directing traffic for a destination network.
+          required:
+            - destination
+            - gateway
+          properties:
+            destination:
+              description: The destination network, in CIDR notation, that this route matches.
+              oneOf:
+                - $ref: ../../components/schemas/Cidr.yml
+                - type: "null"
+                - $ref: StackVariable.yml
+            gateway:
+              description: The IP address that traffic matching the destination is forwarded to.
+              oneOf:
+                - $ref: ../../components/schemas/IpAddress.yml
+                - $ref: StackVariable.yml
+            interface:
+              description: The name of the network interface this route is bound to.
+              oneOf:
+                - type: string
+                - $ref: StackVariable.yml
+      - $ref: StackVariable.yml
   hostname:
     description: The hostname of the container. This is how it can be referenced by other containers in the same environment.
     oneOf:
@@ -28,7 +62,23 @@ properties:
         items:
           type: string
         examples:
-          - "80:80"
-          - "443:80"
-          - "3000"
+          - ["80:80", "443:80", "3000"]
+      - $ref: StackVariable.yml
+  l2:
+    description: Layer 2 network configuration options for containers running on virtual provider servers.
+    oneOf:
+      - type: object
+        required:
+          - domains
+        properties:
+          domains:
+            description: |
+              The layer 2 'domains' that this container's instances should bridge to on the host server.
+              If the host has a matching layer 2 NIC configured via a virtual provider ISO, this container's instances
+              will be joined directly to the host's network.
+            oneOf:
+              - type: array
+                items:
+                  $ref: ../../components/schemas/sdn/L2Domain.yml
+              - $ref: StackVariable.yml
       - $ref: StackVariable.yml

--- a/stackspec/schema/StackSpecContainerConfigNetwork.yml
+++ b/stackspec/schema/StackSpecContainerConfigNetwork.yml
@@ -1,5 +1,4 @@
 title: StackSpecContainerConfigNetwork
-x-ogen-name: StackSpecContainerConfigNetwork
 description: Stack configuration options related to the container's network.
 type: object
 required:

--- a/stackspec/schema/StackVariable.yml
+++ b/stackspec/schema/StackVariable.yml
@@ -1,6 +1,6 @@
 title: StackVariable
 description: A variable specified in a stack spec.
-pattern: \"?{{(\$)?([a-z0-9\-]+)}}\"?
+pattern: '"?\{\{(\$)?([a-z0-9-]+)\}\}"?'
 type: string
 examples:
   - "{{$stack-variable}}"


### PR DESCRIPTION
Adds two new options to the container network config
- `egress_via_gateway`: Routes traffic from the container out to the environment's gateway service, operating the same as a virtual machine in the same environment.
- `routes`: Custom network routes, where you can match CIDRs and forward that traffic to a target gateway. This allows for very advanced network options like utilizing VPNs within an environment for outbound traffic.