### PR TITLE
High Availability Checkin [Internal API]

### DIFF
--- a/components/schemas/containers/Container.yml
+++ b/components/schemas/containers/Container.yml
@@ -13,6 +13,9 @@ required:
   - instances
   - stateful
   - state
+  - role
+  - ha
+  - deployment
   - deprecate
   - lock
   - events
@@ -62,6 +65,11 @@ properties:
       - type: string
         enum:
           - orchestrator
+      - type: "null"
+  ha:
+    description: High availability status of the container. Contains information about the primary instance, if any.
+    oneOf:
+      - $ref: ./ha/ContainerHighAvailability.yml
       - type: "null"
   stateful:
     type: boolean

--- a/components/schemas/containers/config/ContainerDeploy.yml
+++ b/components/schemas/containers/config/ContainerDeploy.yml
@@ -12,6 +12,11 @@ properties:
       - $ref: ../../infrastructure/DeploymentStrategyName.yml
       - type: "null"
     description: The deployment strategy to use when scaling the given container.
+  ha:
+    description: Configuration options for how the platform treats instances of this container when opting into high availability via the internal API.
+    oneOf:
+      - $ref: ./deploy/ContainerDeployHighAvailabilityConfig.yml
+      - type: "null"
   function:
     description: Configuration options for containers using the 'function' deployment strategy.
     oneOf:

--- a/components/schemas/containers/config/deploy/ContainerDeployHighAvailabilityConfig.yml
+++ b/components/schemas/containers/config/deploy/ContainerDeployHighAvailabilityConfig.yml
@@ -1,0 +1,10 @@
+title: ContainerDeployHighAvailabilityConfig
+description: Configuration options for how the platform treats instances of this container when opting into high availability via the internal API.
+required:
+  - stale_primary_deadline
+properties:
+  stale_primary_deadline:
+    description: The amount of time that must pass between high availability checkins before an instance is considered stale. If it is the primary, a new primary will be elected after this deadline. Minimum is 15s.
+    oneOf:
+      - $ref: ../../../Duration.yml
+      - type: "null"

--- a/components/schemas/containers/ha/ContainerHighAvailability.yml
+++ b/components/schemas/containers/ha/ContainerHighAvailability.yml
@@ -1,0 +1,17 @@
+title: ContainerHighAvailability
+description: |
+  The high availability configuration and status for a container, as determined by the platform.
+type: object
+required:
+  - enable
+  - primary
+properties:
+  enable:
+    type: boolean
+    description: Whether high availability is enabled for this container.
+  primary:
+    description: |
+      Information about the instance currently elected as the primary for this container. Null when no primary has been elected.
+    oneOf:
+      - $ref: "./ContainerHighAvailabilityPrimary.yml"
+      - type: "null"

--- a/components/schemas/containers/ha/ContainerHighAvailability.yml
+++ b/components/schemas/containers/ha/ContainerHighAvailability.yml
@@ -3,12 +3,12 @@ description: |
   The high availability configuration and status for a container, as determined by the platform.
 type: object
 required:
-  - enable
+  - last_checkin
   - primary
 properties:
-  enable:
-    type: boolean
-    description: Whether high availability is enabled for this container.
+  last_checkin:
+    description: The last time the primary checked in.
+    $ref: ../../DateTime.yml
   primary:
     description: |
       Information about the instance currently elected as the primary for this container. Null when no primary has been elected.

--- a/components/schemas/containers/ha/ContainerHighAvailabilityPrimary.yml
+++ b/components/schemas/containers/ha/ContainerHighAvailabilityPrimary.yml
@@ -14,7 +14,7 @@ properties:
   priority:
     type: integer
     format: int32
-    description: The priority value assigned to this instance for the election.
+    description: The priority value assigned to this instance for the election. Higher priority means more likely to be elected primary.
   elected:
     description: The time at which this instance was elected as the primary.
     $ref: "../../DateTime.yml"

--- a/components/schemas/containers/ha/ContainerHighAvailabilityPrimary.yml
+++ b/components/schemas/containers/ha/ContainerHighAvailabilityPrimary.yml
@@ -1,0 +1,23 @@
+title: ContainerHighAvailabilityPrimary
+description: |
+  Details about the instance currently elected as the high availability primary for a container.
+type: object
+required:
+  - instance_id
+  - priority
+  - elected
+  - last_checkin
+properties:
+  instance_id:
+    description: The ID of the instance that has been elected as the primary.
+    $ref: "../../ID.yml"
+  priority:
+    type: integer
+    format: int32
+    description: The priority value assigned to this instance for the election.
+  elected:
+    description: The time at which this instance was elected as the primary.
+    $ref: "../../DateTime.yml"
+  last_checkin:
+    description: The time the primary instance last checked into the high availability service.
+    $ref: "../../DateTime.yml"

--- a/components/schemas/containers/instances/Instance.yml
+++ b/components/schemas/containers/instances/Instance.yml
@@ -102,6 +102,10 @@ properties:
     anyOf:
       - $ref: ../Deployment.yml
       - type: "null"
+  high_availability:
+    oneOf:
+      - $ref: ./InstanceHighAvailability.yml
+      - type: "null"
   events:
     title: InstanceEvents
     description: A collection of timestamps for each event in the instance's lifetime.

--- a/components/schemas/containers/instances/Instance.yml
+++ b/components/schemas/containers/instances/Instance.yml
@@ -102,7 +102,7 @@ properties:
     anyOf:
       - $ref: ../Deployment.yml
       - type: "null"
-  high_availability:
+  ha:
     oneOf:
       - $ref: ./InstanceHighAvailability.yml
       - type: "null"

--- a/components/schemas/containers/instances/InstanceHighAvailability.yml
+++ b/components/schemas/containers/instances/InstanceHighAvailability.yml
@@ -1,0 +1,15 @@
+title: InstanceHighAvailability
+description: |
+  The high availability status of the instance, as determined by the platform. 
+
+  This data becomes avaialble when utilizing the internal API high availability endpoint. The platform will hold elections for all instances hitting the endpoint and choose a primary. As long as those instances continue to check in, the primary will continue to be the primary until it is dropped off. After which, a secondary will be promoted.
+type: object
+properties:
+  elected_primary:
+    description: If a time is set, indicates that this instance is the primary, and the time at which it was promoted.
+    oneOf:
+      - $ref: "../../DateTime.yml"
+      - type: "null"
+  last_verify:
+    description: The time that the instance last checked into the HA service.
+    $ref: "../../DateTime.yml"

--- a/components/schemas/containers/instances/InstanceHighAvailability.yml
+++ b/components/schemas/containers/instances/InstanceHighAvailability.yml
@@ -4,12 +4,14 @@ description: |
 
   This data becomes avaialble when utilizing the internal API high availability endpoint. The platform will hold elections for all instances hitting the endpoint and choose a primary. As long as those instances continue to check in, the primary will continue to be the primary until it is dropped off. After which, a secondary will be promoted.
 type: object
+required:
+  - last_checkin
 properties:
   elected_primary:
     description: If a time is set, indicates that this instance is the primary, and the time at which it was promoted.
     oneOf:
       - $ref: "../../DateTime.yml"
       - type: "null"
-  last_verify:
+  last_checkin:
     description: The time that the instance last checked into the HA service.
     $ref: "../../DateTime.yml"

--- a/components/schemas/containers/summaries/ContainerSummary.yml
+++ b/components/schemas/containers/summaries/ContainerSummary.yml
@@ -38,6 +38,11 @@ properties:
       - type: "null"
   state:
     $ref: "../ContainerState.yml"
+  ha:
+    description: High availability status of the container. Contains information about the primary instance, if any.
+    oneOf:
+      - $ref: ../ha/ContainerHighAvailability.yml
+      - type: "null"
   role:
     type:
       - string

--- a/internal/api.yml
+++ b/internal/api.yml
@@ -84,6 +84,10 @@ paths:
   /v1/conductor/tasks:
     $ref: paths/conductor/tasks.yml
 
+  # HA
+  /v1/ha/checkin:
+    $ref: paths/ha/checkin.yml
+
   # Monitoring
   /v1/monitoring/metrics:
     $ref: paths/monitoring/metrics.yml
@@ -101,7 +105,7 @@ paths:
     $ref: paths/sdn/instances.yml
   /v1/sdn/networks/environments:
     $ref: paths/sdn/environments.yml
-  
+
   # Virtual Machines
   /v1/virtual-machine:
     $ref: paths/virtual-machine/virtual-machine.yml
@@ -109,7 +113,6 @@ paths:
     $ref: paths/virtual-machine/domains.yml
   /v1/virtual-machine/gateways:
     $ref: paths/virtual-machine/gateways.yml
-
 
   # Object Cache
   /v1/object-cache:

--- a/internal/paths/environment/containers.yml
+++ b/internal/paths/environment/containers.yml
@@ -4,7 +4,6 @@ get:
   description: Lists all Containers that are part of the same Environment as this Instance.
   tags:
     - Environments
-    - Containers
   parameters: []
   responses:
     default:

--- a/internal/paths/environment/scoped-variables.yml
+++ b/internal/paths/environment/scoped-variables.yml
@@ -4,7 +4,6 @@ get:
   description: |
     Gets the scoped variables that are accessible to this instance via internal API.
   tags:
-    - Environments
     - Scoped Variables
   parameters: []
   responses:

--- a/internal/paths/ha/checkin.yml
+++ b/internal/paths/ha/checkin.yml
@@ -1,0 +1,51 @@
+post:
+  operationId: haCheckin
+  summary: High Availability Checkin
+  description: |
+    Hit this endpoint every 30 seconds to check in and have the platform select and maintain a primary instance.
+    Every instance you wish to be considered for a primary should hit this endpoint roughly every 30 seconds. The platform will choose one instance as the primary, and it will continue to be the primary until it stops checking in. If a primary stops checking in, a secondary will be selected to be promoted to primary.
+  tags:
+    - High Availability
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - electable
+            - priority
+          properties:
+            electable:
+              type: boolean
+              description: Whether this instance wishes to be considered for election as the primary.
+            priority:
+              type: integer
+              format: int32
+              description: The election priority for this instance.
+  responses:
+    "200":
+      description: Returns the result of the high availability check-in.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                type: object
+                required:
+                  - time
+                  - primary_instance_id
+                properties:
+                  time:
+                    description: The time the platform recorded this check-in.
+                    $ref: "../../../components/schemas/DateTime.yml"
+                  primary_instance_id:
+                    description: The ID of the instance currently elected as the primary. Null when no primary has been elected yet.
+                    oneOf:
+                      - $ref: "../../../components/schemas/ID.yml"
+                      - type: "null"
+    default:
+      $ref: ../../../components/responses/errors/DefaultError.yml

--- a/internal/paths/ha/checkin.yml
+++ b/internal/paths/ha/checkin.yml
@@ -1,5 +1,5 @@
 post:
-  operationId: haCheckin
+  operationId: highAvailabilityCheckin
   summary: High Availability Checkin
   description: |
     Hit this endpoint every 30 seconds to check in and have the platform select and maintain a primary instance.
@@ -22,7 +22,7 @@ post:
             priority:
               type: integer
               format: int32
-              description: The election priority for this instance.
+              description: The election priority for this instance. Higher priority means more likely to be elected primary.
   responses:
     "200":
       description: Returns the result of the high availability check-in.

--- a/stackspec/schema/StackSpecContainer.yml
+++ b/stackspec/schema/StackSpecContainer.yml
@@ -11,7 +11,6 @@ properties:
     type: string
     description: The human-readable name of this container.
   image:
-    x-ogen-name: StackSpecContainerImageProperty
     description: Details about the image used for this container.
     oneOf:
       - $ref: StackSpecContainerImage.yml

--- a/stackspec/schema/StackSpecContainerConfigDeploy.yml
+++ b/stackspec/schema/StackSpecContainerConfigDeploy.yml
@@ -35,6 +35,12 @@ properties:
       - type: "null"
       - $ref: StackVariable.yml
 
+  ha:
+    oneOf:
+      - $ref: ./deploy/StackSpecContainerConfigHighAvailability.yml
+      - type: "null"
+      - $ref: StackVariable.yml
+
   function:
     description: Configuration options for containers using the 'function' deployment strategy.
     oneOf:

--- a/stackspec/schema/StackVariable.yml
+++ b/stackspec/schema/StackVariable.yml
@@ -3,4 +3,5 @@ description: A variable specified in a stack spec.
 pattern: '"?\{\{(\$)?([a-z0-9-]+)\}\}"?'
 type: string
 examples:
+  - "{{stack-variable}}"
   - "{{$stack-variable}}"

--- a/stackspec/schema/deploy/StackSpecContainerConfigHighAvailability.yml
+++ b/stackspec/schema/deploy/StackSpecContainerConfigHighAvailability.yml
@@ -1,0 +1,10 @@
+title: StackSpecContainerConfigHighAvailability
+description: Configuration options for how the platform treats instances of this container when opting into high availability via the internal API.
+required:
+  - stale_primary_deadline
+properties:
+  stale_primary_deadline:
+    description: The amount of time that must pass between high availability checkins before an instance is considered stale. If it is the primary, a new primary will be elected after this deadline. Minimum is 15s.
+    oneOf:
+      - $ref: ../../../components/schemas/Duration.yml
+      - $ref: ../StackVariable.yml


### PR DESCRIPTION
Adding a new feature to the internal API: the ability to manage high available instances by having the platform determine and maintain a 'primary' instance from a pool of instances hitting this endpoint at a regular interval.

This is a lease-based leader election for active-passive failover. Instances will check in every 30 seconds or so, and the platform will maintain the primary until it either drops off for a couple minutes, or reports itself as unelectable. Then the platform will determine a new primary. 

Applications can use this response to perform tasks only one instance should do while maintaining high availability, etc.