### PR TITLE
Update monitor endpoint to `platform/monitor`

### DIFF
--- a/platform/api.yml
+++ b/platform/api.yml
@@ -684,7 +684,7 @@ paths:
     $ref: paths/monitoring/events/aggregate.yml
   "/v1/monitoring/logs/aggregate":
     $ref: paths/monitoring/logs/aggregate.yml
-  "/v1/monitoring/monitors":
+  "/v1/monitoring/platform/monitors":
     $ref: paths/monitoring/monitors/monitors.yml
 
   # --Pipelines


### PR DESCRIPTION
 "/v1/monitoring/monitors": becomes  "/v1/monitoring/platform/monitors":
 
 We're expanding monitoring support and /monitoring/monitors will be used for custom monitoring/alerting